### PR TITLE
radiobutton: don't consider hidden buttons in the group for focus

### DIFF
--- a/gtk/gtkradiobutton.c
+++ b/gtk/gtkradiobutton.c
@@ -745,7 +745,8 @@ gtk_radio_button_focus (GtkWidget         *widget,
       tmp_slist = priv->group;
       while (tmp_slist)
 	{
-	  if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (tmp_slist->data)))
+	  if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (tmp_slist->data)) &&
+	      gtk_widget_get_visible (tmp_slist->data))
 	    selected_button = tmp_slist->data;
 	  tmp_slist = tmp_slist->next;
 	}


### PR DESCRIPTION
When a GtkRadioButton has no focus, it will accept it when there is no
other active button in its group.
If the active button in the group is hidden, for example because the UI
desires not to have a default option pre-selected, currently the focus
will not be accepted, which is not desired behavior.

This commit changes the code to only consider visible buttons in the
group when checking whether another button is active.

[endlessm/eos-shell#3285]
