### PR TITLE
Fix sizing bug in gtkentrycompletion with multiple cells

### DIFF
--- a/gtk/gtkentrycompletion.c
+++ b/gtk/gtkentrycompletion.c
@@ -1480,6 +1480,7 @@ _gtk_entry_completion_resize_popup (GtkEntryCompletion *completion)
   GdkWindow *window;
   GtkRequisition popup_req;
   GtkRequisition entry_req;
+  GtkRequisition tree_req;
   GtkTreePath *path;
   gboolean above;
   gint width;
@@ -1506,6 +1507,11 @@ _gtk_entry_completion_resize_popup (GtkEntryCompletion *completion)
   actions = gtk_tree_model_iter_n_children (GTK_TREE_MODEL (completion->priv->actions), NULL);
   action_column  = gtk_tree_view_get_column (GTK_TREE_VIEW (completion->priv->action_view), 0);
 
+  /* Call get preferred size on the on the tree view to force it to validate its
+   * cells before calling into the cell size functions.
+   */
+  gtk_widget_get_preferred_size (completion->priv->tree_view,
+                                 &tree_req, NULL);
   gtk_tree_view_column_cell_get_size (completion->priv->column, NULL,
                                       NULL, NULL, NULL, &height);
   gtk_tree_view_column_cell_get_size (action_column, NULL,


### PR DESCRIPTION
The entry completion is the only place in the entire gtk code base
that calls gtk_tree_view_column_cell_get_size outside of gtktreeview
itself. It calls into the function before the tree view has done some
important validation on its cell state, the net result of which is
only the first element in the gtkcellareabox the entry completion uses
well actually have its size respected.

We now call gtk_widget_get_preferred_size on the tree view before
calling into the individual cell size routines, to guarantee that the
tree view has run its validate_rows routine and cell state is valid.
[endlessm/eos-shell#3976]
