### PR TITLE
icontheme: allow directories with mtime 0

### DIFF
--- a/gtk/gtkicontheme.c
+++ b/gtk/gtkicontheme.c
@@ -323,6 +323,7 @@ typedef struct
 {
   char *dir;
   time_t mtime; /* 0 == not existing or not a dir */
+  gboolean exists;
 
   GtkIconCache *cache;
 } IconThemeDirMtime;
@@ -1110,9 +1111,15 @@ insert_theme (GtkIconTheme *icon_theme, const char *theme_name)
       dir_mtime->cache = NULL;
       dir_mtime->dir = path;
       if (g_stat (path, &stat_buf) == 0 && S_ISDIR (stat_buf.st_mode))
-	dir_mtime->mtime = stat_buf.st_mtime;
+	{
+	  dir_mtime->mtime = stat_buf.st_mtime;
+	  dir_mtime->exists = TRUE;
+	}
       else
-	dir_mtime->mtime = 0;
+	{
+	  dir_mtime->mtime = 0;
+	  dir_mtime->exists = FALSE;
+	}
 
       priv->dir_mtimes = g_list_prepend (priv->dir_mtimes, dir_mtime);
     }
@@ -1274,11 +1281,13 @@ load_themes (GtkIconTheme *icon_theme)
       
       dir_mtime->dir = g_strdup (dir);
       dir_mtime->mtime = 0;
+      dir_mtime->exists = FALSE;
       dir_mtime->cache = NULL;
 
       if (g_stat (dir, &stat_buf) != 0 || !S_ISDIR (stat_buf.st_mode))
 	continue;
       dir_mtime->mtime = stat_buf.st_mtime;
+      dir_mtime->exists = TRUE;
 
       dir_mtime->cache = _gtk_icon_cache_new_for_path (dir);
       if (dir_mtime->cache != NULL)
@@ -2539,12 +2548,12 @@ rescan_themes (GtkIconTheme *icon_theme)
       stat_res = g_stat (dir_mtime->dir, &stat_buf);
 
       /* dir mtime didn't change */
-      if (stat_res == 0 &&
+      if (stat_res == 0 && dir_mtime->exists &&
 	  S_ISDIR (stat_buf.st_mode) &&
 	  dir_mtime->mtime == stat_buf.st_mtime)
 	continue;
       /* didn't exist before, and still doesn't */
-      if (dir_mtime->mtime == 0 &&
+      if (!dir_mtime->exists &&
 	  (stat_res != 0 || !S_ISDIR (stat_buf.st_mode)))
 	continue;
 
@@ -3196,7 +3205,7 @@ theme_subdir_load (GtkIconTheme *icon_theme,
     {
       dir_mtime = (IconThemeDirMtime *)d->data;
 
-      if (dir_mtime->mtime == 0)
+      if (!dir_mtime->exists)
 	continue; /* directory doesn't exist */
 
        full_dir = g_build_filename (dir_mtime->dir, subdir, NULL);


### PR DESCRIPTION
In order to provide a constant mtime between OS build and deploy time,
while also maintaining a hardlink content-addressed model independent of
timestamps, ostree sets all mtimes to 0.

The icon cache code currently ignores directories with mtime 0, assuming
they don't exist.

Track directory existence in a more precise way.

https://bugzilla.gnome.org/show_bug.cgi?id=745052
https://github.com/endlessm/eos-shell/issues/4601