### PR TITLE
window: fix initial shadow width for maximized/fullscreen windows

### DIFF
--- a/gtk/gtkwindow.c
+++ b/gtk/gtkwindow.c
@@ -5610,6 +5610,8 @@ gtk_window_map (GtkWidget *widget)
   else
     gdk_window_unmaximize (gdk_window);
 
+  priv->maximize_initially = FALSE;
+
   if (priv->stick_initially)
     gdk_window_stick (gdk_window);
   else
@@ -5624,6 +5626,8 @@ gtk_window_map (GtkWidget *widget)
     gdk_window_fullscreen (gdk_window);
   else
     gdk_window_unfullscreen (gdk_window);
+
+  priv->fullscreen_initially = FALSE;
 
   gdk_window_set_keep_above (gdk_window, priv->above_initially);
 
@@ -6568,7 +6572,9 @@ get_shadow_width (GtkWidget *widget,
     return;
 
   if (priv->maximized ||
+      priv->maximize_initially ||
       priv->fullscreen ||
+      priv->fullscreen_initially ||
       priv->tiled)
     return;
 


### PR DESCRIPTION
To calculate the shadow width, we look at the value of priv->fullscreen
and priv->maximized.
Those fields will have the actual value only after GTK receives back a
window state event though, so they will be wrong in _realize(). Look at
priv->fullscreen_initially and priv->maximize_initially too, to avoid
the size changing right after realize, which would make the window
flicker if maximized at startup.

[endlessm/eos-shell#4943]