### PR TITLE
Makefile: Move to AM_DISTCHECK_CONFIGURE_FLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,7 +95,7 @@ ChangeLog:
 uninstall-local:
 	rm -f $(DESTDIR)$(pkgconfigdir)/gtk+-3.0.pc
 
-DISTCHECK_CONFIGURE_FLAGS =		\
+AM_DISTCHECK_CONFIGURE_FLAGS =		\
 	--enable-gtk-doc 		\
 	--disable-doc-cross-references  \
 	--enable-man 			\

--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ AC_SUBST(INTROSPECTION_REQUIRED_VERSION)
 # Save this value here, since automake will set cflags later
 cflags_set=${CFLAGS+set}
 
-AM_INIT_AUTOMAKE([1.11 -Wall no-define -Wno-portability tar-ustar no-dist-gzip dist-xz])
+AM_INIT_AUTOMAKE([1.11.2 -Wall no-define -Wno-portability tar-ustar no-dist-gzip dist-xz])
 AM_MAINTAINER_MODE([enable])
 
 # Support silent build rules. Disable


### PR DESCRIPTION
Since automake 1.11.2 it is recommended that packages
use AM_DISTCHECK_CONFIGURE_FLAGS instead of
DISTCHECK_CONFIGURE_FLAGS as the latter is intended
to be a user variable.

[endlessm/eos-sdk#3303]