### PR TITLE
gtkwindow: add an environment variable to disable backdrop styling

### DIFF
--- a/gtk/gtkwindow.c
+++ b/gtk/gtkwindow.c
@@ -11733,6 +11733,9 @@ ensure_state_flag_backdrop (GtkWidget *widget)
   GdkWindow *window;
   gboolean window_focused = TRUE;
 
+  if (g_strcmp0 (g_getenv ("GTK_BACKDROP_STYLING"), "0") == 0)
+    return;
+
   window = gtk_widget_get_window (widget);
 
   window_focused = gdk_window_get_state (window) & GDK_WINDOW_STATE_FOCUSED;


### PR DESCRIPTION
Some applications are always on top, or don't have different styles for
backdrop. In that case, it's desirable not to pay the performance
penalty of backdrop style switching.
Add an environment variable as a low-tech way for applications to ask
for that behavior.

[endlessm/eos-shell#5813]