### PR TITLE
Add back libxml2-utils dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,6 +47,7 @@ Build-Depends: debhelper (>= 8.1.3),
                libjson-glib-dev,
                gobject-introspection (>= 1.41.3),
                libgirepository1.0-dev (>= 1.39.0),
+               libxml2-utils,
                xvfb
 Build-Depends-Indep: docbook-xml,
                      docbook-utils,

--- a/debian/control.in
+++ b/debian/control.in
@@ -47,6 +47,7 @@ Build-Depends: debhelper (>= 8.1.3),
                libjson-glib-dev,
                gobject-introspection (>= 1.41.3),
                libgirepository1.0-dev (>= 1.39.0),
+               libxml2-utils,
                xvfb
 Build-Depends-Indep: docbook-xml,
                      docbook-utils,


### PR DESCRIPTION
Apparently whatever pulling the xmlcatalog tool on debian is not working
for us
[endlessm/eos-sdk#3590]