### PR TITLE
Tweak startup-notification after the first window

### DIFF
--- a/gdk/x11/gdkdisplay-x11.c
+++ b/gdk/x11/gdkdisplay-x11.c
@@ -2275,9 +2275,15 @@ static void
 gdk_x11_display_notify_startup_complete (GdkDisplay  *display,
                                          const gchar *startup_id)
 {
+  gchar *free_this = NULL;
+
   if (startup_id == NULL)
     {
-      startup_id = GDK_X11_DISPLAY (display)->startup_notification_id;
+      GdkX11Display *display_x11 = GDK_X11_DISPLAY (display);
+
+      startup_id = free_this = display_x11->startup_notification_id;
+      display_x11->startup_notification_id = NULL;
+
       if (startup_id == NULL)
         return;
     }
@@ -2285,6 +2291,8 @@ gdk_x11_display_notify_startup_complete (GdkDisplay  *display,
   gdk_x11_display_broadcast_startup_message (display, "remove",
                                              "ID", startup_id,
                                              NULL);
+
+  g_free (free_this);
 }
 
 static gboolean

--- a/gtk/gtkapplication.c
+++ b/gtk/gtkapplication.c
@@ -676,8 +676,6 @@ static void
 gtk_application_after_emit (GApplication *application,
                             GVariant     *platform_data)
 {
-  gdk_notify_startup_complete ();
-
   gdk_threads_leave ();
 }
 

--- a/gtk/gtkwindow.c
+++ b/gtk/gtkwindow.c
@@ -520,7 +520,6 @@ static GList       *default_icon_list = NULL;
 static gchar       *default_icon_name = NULL;
 static guint        default_icon_serial = 0;
 static gboolean     disable_startup_notification = FALSE;
-static gboolean     sent_startup_notification = FALSE;
 
 static GQuark       quark_gtk_embedded = 0;
 static GQuark       quark_gtk_window_key_hash = 0;
@@ -6112,9 +6111,8 @@ gtk_window_map (GtkWidget *widget)
           g_free (priv->startup_id);
           priv->startup_id = NULL;
         }
-      else if (!sent_startup_notification)
+      else
         {
-          sent_startup_notification = TRUE;
           gdk_notify_startup_complete ();
         }
     }


### PR DESCRIPTION
Presently, Gtk will only send a startup notification completion message
for the first window that is shown.  This is not good for the case of
GtkApplication, where we are expected to participate in
startup-notification for all windows.

We have avoided this problem by manually emitting the startup complete
message from after_emit in GtkApplication.

Unfortunately, this causes problems for windows that are shown with a
delay.  It is also a dirty hack.

The reason for the original behaviour is simple: there is a static
boolean in gtkwindow.c which controls it.  We remove this.

Instead, clear the startup notification ID stored in GDK when sending
the completion message.  GtkApplication will re-set this the next time
an event comes in which needs startup-notification handling.  In the
non-GtkApplication case, newly shown windows will still not send the
message, since the cookie will have been cleared.

Finally, we remove the hack from GtkApplication's after_emit.

This will probably cause some regressions in terms of lingering startup
notification messages.  The correct solution here is to always use
gtk_window_present(), including when merely opening a new document (with
a new tab, for example).

https://bugzilla.gnome.org/show_bug.cgi?id=690791

[endlessm/eos-sdk#3949]