### PR TITLE
Adwaita: No rounded corners for fullscreen

### DIFF
--- a/gtk/theme/Adwaita/_common.scss
+++ b/gtk/theme/Adwaita/_common.scss
@@ -3282,6 +3282,7 @@ GtkVolumeButton.button {
     box-shadow: 0 2px 6px 2px transparentize(black, 0.8),
                 0 0 0 1px $_wm_border_backdrop;
   }
+  &.fullscreen,
   &.tiled {
     border-radius: 0;
   }

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -4230,7 +4230,7 @@ GtkColorSwatch {
   margin: 10px; }
   .window-frame:backdrop {
     box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(28, 31, 31, 0.9); }
-  .window-frame.tiled {
+  .window-frame.fullscreen, .window-frame.tiled {
     border-radius: 0; }
   .window-frame.popup {
     box-shadow: none; }

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -4402,7 +4402,7 @@ GtkColorSwatch {
   margin: 10px; }
   .window-frame:backdrop {
     box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(0, 0, 0, 0.18); }
-  .window-frame.tiled {
+  .window-frame.fullscreen, .window-frame.tiled {
     border-radius: 0; }
   .window-frame.popup {
     box-shadow: none; }


### PR DESCRIPTION
If the theme has rounded corners for fullscreen, we don't tell the
window manager that we are now fully opaque, which then makes things
less efficient than they should be.

https://bugzilla.gnome.org//show_bug.cgi?id=761571
[endlessm/eos-shell#6289]