### PR TITLE
New symbols for unstable api we are bringing in

### DIFF
--- a/debian/libgtk-3-0.symbols
+++ b/debian/libgtk-3-0.symbols
@@ -4732,6 +4732,7 @@ libgtk-3.so.0 libgtk-3-0 #MINVER#
  gtk_widget_get_action_group@Base 3.16.2
  gtk_widget_get_allocated_baseline@Base 3.9.10
  gtk_widget_get_allocated_height@Base 3.0.0
+ gtk_widget_get_allocated_size@Base 3.18.6
  gtk_widget_get_allocated_width@Base 3.0.0
  gtk_widget_get_allocation@Base 3.0.0
  gtk_widget_get_ancestor@Base 3.0.0
@@ -4892,6 +4893,7 @@ libgtk-3.so.0 libgtk-3-0 #MINVER#
  gtk_widget_path_unref@Base 3.1.6
  gtk_widget_pop_composite_child@Base 3.0.0
  gtk_widget_push_composite_child@Base 3.0.0
+ gtk_widget_queue_allocate@Base 3.18.6
  gtk_widget_queue_compute_expand@Base 3.0.0
  gtk_widget_queue_draw@Base 3.0.0
  gtk_widget_queue_draw_area@Base 3.0.0


### PR DESCRIPTION
When we update to the next stable release, these will be symbols
for 3.20, not 3.18