### PR TITLE
wayland symbols only for intel

### DIFF
--- a/debian/libgtk-3-0.symbols
+++ b/debian/libgtk-3-0.symbols
@@ -432,24 +432,24 @@ libgdk-3.so.0 libgtk-3-0 #MINVER#
  gdk_visual_get_type@Base 3.0.0
  gdk_visual_get_visual_type@Base 3.0.0
  gdk_visual_type_get_type@Base 3.0.0
- (arch=linux-any)gdk_wayland_device_get_type@Base 3.9.10
- (arch=linux-any)gdk_wayland_device_get_wl_keyboard@Base 3.9.10
- (arch=linux-any)gdk_wayland_device_get_wl_pointer@Base 3.9.10
- (arch=linux-any)gdk_wayland_device_get_wl_seat@Base 3.9.10
- (arch=linux-any)gdk_wayland_display_get_type@Base 3.9.10
- (arch=linux-any)gdk_wayland_display_get_wl_compositor@Base 3.9.10
- (arch=linux-any)gdk_wayland_display_get_wl_display@Base 3.9.10
- (arch=linux-any)gdk_wayland_display_get_xdg_shell@Base 3.11.5
- (arch=linux-any)gdk_wayland_display_set_cursor_theme@Base 3.9.10
-#MISSING: 3.19.12-1# (arch=linux-any)gdk_wayland_drag_context_get_dnd_window_libgtk_only@Base 3.13.8
- (arch=linux-any)gdk_wayland_gl_context_get_type@Base 3.16.2
- (arch=linux-any)gdk_wayland_seat_get_wl_seat@Base 3.19.12
- (arch=linux-any)gdk_wayland_selection_add_targets_libgtk_only@Base 3.13.8
- (arch=linux-any)gdk_wayland_selection_clear_targets_libgtk_only@Base 3.13.8
- (arch=linux-any)gdk_wayland_window_get_type@Base 3.9.10
- (arch=linux-any)gdk_wayland_window_get_wl_surface@Base 3.9.10
- (arch=linux-any)gdk_wayland_window_set_dbus_properties_libgtk_only@Base 3.10.0
- (arch=linux-any)gdk_wayland_window_set_use_custom_surface@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_device_get_type@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_device_get_wl_keyboard@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_device_get_wl_pointer@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_device_get_wl_seat@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_display_get_type@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_display_get_wl_compositor@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_display_get_wl_display@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_display_get_xdg_shell@Base 3.11.5
+ (arch=linux-i386 linux-amd64)gdk_wayland_display_set_cursor_theme@Base 3.9.10
+#MISSING: 3.19.12-1# (arch=linux-i386 linux-amd64)gdk_wayland_drag_context_get_dnd_window_libgtk_only@Base 3.13.8
+ (arch=linux-i386 linux-amd64)gdk_wayland_gl_context_get_type@Base 3.16.2
+ (arch=linux-i386 linux-amd64)gdk_wayland_seat_get_wl_seat@Base 3.19.12
+ (arch=linux-i386 linux-amd64)gdk_wayland_selection_add_targets_libgtk_only@Base 3.13.8
+ (arch=linux-i386 linux-amd64)gdk_wayland_selection_clear_targets_libgtk_only@Base 3.13.8
+ (arch=linux-i386 linux-amd64)gdk_wayland_window_get_type@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_window_get_wl_surface@Base 3.9.10
+ (arch=linux-i386 linux-amd64)gdk_wayland_window_set_dbus_properties_libgtk_only@Base 3.10.0
+ (arch=linux-i386 linux-amd64)gdk_wayland_window_set_use_custom_surface@Base 3.9.10
  gdk_window_add_filter@Base 3.0.0
  gdk_window_at_pointer@Base 3.0.0
  gdk_window_attributes_type_get_type@Base 3.0.0


### PR DESCRIPTION
We can't support the wayland backend on arm because of our old
kernel version there.
https://phabricator.endlessm.com/T11000