### PR TITLE
_gtk_icon_helper_draw: get style earlier

### DIFF
--- a/gtk/gtkiconhelper.c
+++ b/gtk/gtkiconhelper.c
@@ -892,11 +892,12 @@ _gtk_icon_helper_draw (GtkIconHelper *self,
                        gdouble x,
                        gdouble y)
 {
+  GtkCssStyle *style = gtk_css_node_get_style (gtk_css_gadget_get_node (GTK_CSS_GADGET (self)));
   gtk_icon_helper_ensure_surface (self);
 
   if (self->priv->rendered_surface != NULL)
     {
-      gtk_css_style_render_icon_surface (gtk_css_node_get_style (gtk_css_gadget_get_node (GTK_CSS_GADGET (self))),
+      gtk_css_style_render_icon_surface (style,
                                          cr,
                                          self->priv->rendered_surface,
                                          x, y);


### PR DESCRIPTION
After checking for rendered_surface, the call to gtk_css_node_get_style
can invalidate the style and result in rendered_surface being set to
NULL. This was result in some icon views appearing blank on
Endless OS on armv7hl, and this error:

Gtk-CRITICAL **: gtk_css_style_render_icon_surface: assertion 'surface != NULL' failed

Call gtk_css_node_get_style earlier to ensure we always pass a valid
surface to gtk_css_style_render_icon_surface.

https://bugzilla.gnome.org/show_bug.cgi?id=765649
https://phabricator.endlessm.com/T13524