### PR TITLE
TMP: Remove broken reftests

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -42,5 +42,13 @@ else
         autoreconf --force --install --verbose || exit $?
 fi
 
+# These reftests fail on autobuilders, see corresponding commit on Debian branch
+touch testsuite/reftests/window-show-contents-on-map.ui.known_fail
+touch testsuite/reftests/inherit-and-initial.ui.known_fail
+touch testsuite/reftests/textview-margins.ui.known_fail
+touch testsuite/reftests/box-shadow-changes-modify-clip.ui.known_fail
+touch testsuite/reftests/label-sizing.ui.known_fail
+touch testsuite/reftests/label-text-shadow-changes-modify-clip.ui.known_fail
+
 cd "$olddir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/testsuite/reftests/Makefile.am
+++ b/testsuite/reftests/Makefile.am
@@ -63,6 +63,15 @@ gtk_reftest_SOURCES = \
 	gtk-reftest.c			\
 	gtk-reftest.h
 
+EXTRA_DIST += \
+	window-show-contents-on-map.ui.known_fail \
+	inherit-and-initial.ui.known_fail \
+	textview-margins.ui.known_fail \
+	box-shadow-changes-modify-clip.ui.known_fail \
+	label-sizing.ui.known_fail \
+	label-text-shadow-changes-modify-clip.ui.known_fail \
+	$(NULL)
+
 clean-local:
 	rm -rf output/ || true
 


### PR DESCRIPTION
This does the same thing as the corresponding commit on the Debian
branch: skips reftests that are known to fail on the autobuilder.

https://phabricator.endlessm.com/T14197