### PR TITLE
GtkApplication: Lack of optional components shouldn't warn

### DIFF
--- a/gtk/gtkapplication-dbus.c
+++ b/gtk/gtkapplication-dbus.c
@@ -192,7 +192,7 @@ gtk_application_impl_dbus_startup (GtkApplicationImpl *impl,
 
   if (error)
     {
-      g_warning ("Failed to get the GNOME session proxy: %s", error->message);
+      g_debug ("Failed to get the GNOME session proxy: %s", error->message);
       g_clear_error (&error);
     }
 
@@ -210,7 +210,7 @@ gtk_application_impl_dbus_startup (GtkApplicationImpl *impl,
 
       if (error)
         {
-          g_warning ("Failed to get the Xfce session proxy: %s", error->message);
+          g_debug ("Failed to get the Xfce session proxy: %s", error->message);
           g_clear_error (&error);
           goto out;
         }
@@ -329,7 +329,7 @@ gtk_application_impl_dbus_startup (GtkApplicationImpl *impl,
                                                                           &error);
       if (error)
         {
-          g_warning ("Failed to get an inhibit portal proxy: %s", error->message);
+          g_debug ("Failed to get an inhibit portal proxy: %s", error->message);
           g_clear_error (&error);
         }
     }


### PR DESCRIPTION
The GNOME session manager, the Xfce session manager, and the Inhibit
portal are all not needed for normal operation of GTK, and it's expected
that they're not present on some systems. So we should not log warnings
if they are not found.

https://bugzilla.gnome.org/show_bug.cgi?id=774784
https://phabricator.endlessm.com/T14586