### PR TITLE
GdkX11GLContext: x11-eglx, implemented texture_from_surface()

### DIFF
--- a/gdk/x11/gdkdisplay-x11.h
+++ b/gdk/x11/gdkdisplay-x11.h
@@ -150,6 +150,7 @@ struct _GdkX11Display
   guint has_visual_rating : 1;
   guint has_create_es2_context : 1;
   guint has_swap_buffers_with_damage : 1;
+  guint has_image_pixmap : 1;
 };
 
 struct _GdkX11DisplayClass


### PR DESCRIPTION
Use EGL_KHR_image_pixmap extension to implement texture_from_surface() method.
This avoid doing a copy to render GL content to GTK+

https://phabricator.endlessm.com/T15893