### PR TITLE
GdkX11GLContext: fixed swap interval on unredirected windows

### DIFF
--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -814,9 +814,7 @@ gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
        * the swap when drawing on the offscreen, rendering to the screen
        * happens later anyway, and its up to the compositor to sync that
        * to the vblank. */
-      GdkScreen *screen = gdk_window_get_screen (window);
-
-      do_frame_sync = ! gdk_screen_is_composited (screen);
+      do_frame_sync = ! gdk_window_get_composited (screen);
 
       if (do_frame_sync != context_x11->do_frame_sync)
         {


### PR DESCRIPTION
Use gdk_window_get_composited() to check if a particular window is redirected
instead of gdk_screen_is_composited()

https://phabricator.endlessm.com/T15111