### PR TITLE
cssnode: Don't put wrong styles in the style cache

### DIFF
--- a/gtk/gtkcssnode.c
+++ b/gtk/gtkcssnode.c
@@ -434,6 +434,10 @@ gtk_css_node_real_update_style (GtkCssNode   *cssnode,
                                               timestamp,
                                               gtk_css_node_get_style_provider (cssnode),
                                               should_create_transitions (change) ? style : NULL);
+
+      /* Clear the cache again, the static style we looked up above
+       * may have populated it. */
+      g_clear_pointer (&cssnode->cache, gtk_css_node_style_cache_unref);
     }
   else if (static_style != style && (change & GTK_CSS_CHANGE_TIMESTAMP))
     {


### PR DESCRIPTION
~Company ╡ so TL;DR: we put the static style in the cache, but then
       ⤷ ╡ compute a child style from the animated style in the cache
       ⤷ ╡ and we put the child style also in the cache (because
       ⤷ ╡ it's not animated)
       ⤷ ╡ then we run the animation, but reuse the cache every time
       ⤷ ╡ for both child and parent
       ⤷ ╡ so after the animation is done, we end up with a cache that
       ⤷ ╡ has the correct static style for the parent but an
       ⤷ ╡ incorrect static style for the child
       ⤷ ╡ because that static style was computed from the
       ⤷ ╡ initial animated style

This fixes https://bugzilla.gnome.org/show_bug.cgi?id=763517

https://phabricator.endlessm.com/T19435