### PR TITLE
Chromium header bar: fix user button color for Chrome 64

### DIFF
--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -88,7 +88,7 @@ headerbar.default-decoration {
                                     #1e1e1e);
 }
 
-/* Fix color of buttons for Chrome top bar */
+/* Fix color of window management buttons for Chrome top bar */
 button.titlebutton.chromium {
   color: #8c8c8c;
   -gtk-icon-shadow: none;
@@ -103,4 +103,23 @@ button.titlebutton.chromium:hover {
 
 button.titlebutton.chromium:active {
   color: #787878;
+}
+
+/* Fix color of user button for Chrome top bar */
+.header-bar.chromium button:not(.titlebutton) {
+  border: none;
+  box-shadow: none;
+  background-image: none;
+}
+
+.header-bar.chromium button:not(.titlebutton):hover {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(78, 78, 78, 0.8);
+}
+
+.header-bar.chromium button:not(.titlebutton):active {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
This button is now implemented in gtk3 and can be styled via css.

By default, we want the button background to be transparent
and only appear on hover.

https://phabricator.endlessm.com/T20947