### PR TITLE
GtkLabelAccessible: Initialize link before setting parent

### DIFF
--- a/gtk/a11y/gtklabelaccessible.c
+++ b/gtk/a11y/gtklabelaccessible.c
@@ -158,8 +158,8 @@ gtk_label_accessible_link_impl_new (GtkLabelAccessible *label,
   GtkLabelAccessibleLinkImpl *impl;
 
   impl = g_object_new (_gtk_label_accessible_link_impl_get_type (), NULL);
-  atk_object_set_parent (ATK_OBJECT (impl), ATK_OBJECT (label));
   impl->link = gtk_label_accessible_link_new (label, idx);
+  atk_object_set_parent (ATK_OBJECT (impl), ATK_OBJECT (label));
 
   return impl;
 }


### PR DESCRIPTION
Since at-spi-atk commit 96621a5e95 fixed PropertyChange notifications
for AccessibleParent, setting the parent will result in a call to
ref_state_set() which assumes that the object is fully initialized.

https://bugzilla.gnome.org/show_bug.cgi?id=774939

https://phabricator.endlessm.com/T21318