### PR TITLE
Switch rules downstream changes from cdbs to debhelper

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,6 @@
 
 GNOME_MODULE = gtk+
 DISABLE_UPDATE_UPLOADERS = 1
-include /usr/share/cdbs/1/rules/patchsys-quilt.mk
 include /usr/share/gnome-pkg-tools/1/rules/uploaders.mk
 include /usr/share/gnome-pkg-tools/1/rules/gnome-get-source.mk
 include /usr/share/dpkg/default.mk
@@ -44,10 +43,6 @@ EXAMPLES_PKG := gtk-$(APIVER)-examples
 # so append a .gz suffix to avoid dangling symlinks
 NEWS := NEWS$(shell find -maxdepth 1 -size +4k -name NEWS -exec echo ".gz" \;)
 README := README$(shell find -maxdepth 1 -size +4k -name README -exec echo ".gz" \;)
-
-ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH),armel armhf))
-DEB_CONFIGURE_EXTRA_FLAGS += --enable-egl-x11
-endif
 
 # Avoid test failures on buildd environments
 export HOME=$(CURDIR)/debian/build
@@ -121,6 +116,10 @@ ifeq ($(filter %-doc,$(binaries)),)
 configure_flags_deb += --disable-gtk-doc --disable-man
 endif
 
+ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH),armel armhf))
+configure_flags_deb += --enable-egl-x11
+endif
+
 configure_flags_udeb = \
 	--disable-broadway-backend \
 	--disable-wayland-backend \
@@ -134,7 +133,7 @@ configure_flags_udeb = \
 	--disable-xrandr
 
 %:
-	dh $@ --with gir
+	dh $@ --with gir,quilt
 
 override_dh_clean: debian/control
 	# gross kludge to force control generation with the %.in target


### PR DESCRIPTION
Debian upstream rewrote the packaging to not use cdbs, but our
downstream changes didn't follow suit. Use quilt by passing --with-quilt
to dh, and add our --enable-egl-x11 to the variables built up for
dh_auto_configure.

https://phabricator.endlessm.com/T21675