### PR TITLE
Skip building udeb package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,14 @@ include /usr/share/gnome-pkg-tools/1/rules/uploaders.mk
 include /usr/share/gnome-pkg-tools/1/rules/gnome-get-source.mk
 include /usr/share/dpkg/default.mk
 
+# Make debhelper skip the udeb package since it has no use for Endless
+# and somehow makes the armhf build succeed. DH_OPTIONS is normally not
+# suggested, but it has the advantage that both dh and all the dh_*
+# programs will respect it.
+#
+# https://phabricator.endlessm.com/T22286
+export DH_OPTIONS = -N$(UDEB_PKG)
+
 binaries := $(shell dh_listpackages)
 
 # Ensure the build aborts when there are still references to undefined symbols


### PR DESCRIPTION
This prevents the udeb package from being built and for some odd reason
allows the ARM build to succeed. But generally this is something we
should be doing since we have no use for udeb packages. Not only are
they only used in debian-installer (which we don't use), but OBS does
even publish them. Furthermore, disabling the udeb roughly cuts the
build time in half since an entirely separate build is done for the
udeb.

I don't think that doing this via DH_OPTIONS is really the recommended
way to do it, but it ensures that all debhelper usage respects the -N
option needed to skip the udeb package.

https://phabricator.endlessm.com/T22286