### PR TITLE
modules: fix gtk-2.0 paths to gtk-3.0

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -42,5 +42,13 @@ else
         autoreconf --force --install --verbose || exit $?
 fi
 
+# These reftests fail on autobuilders, see corresponding commit on Debian branch
+touch testsuite/reftests/window-show-contents-on-map.ui.known_fail
+touch testsuite/reftests/inherit-and-initial.ui.known_fail
+touch testsuite/reftests/textview-margins.ui.known_fail
+touch testsuite/reftests/box-shadow-changes-modify-clip.ui.known_fail
+touch testsuite/reftests/label-sizing.ui.known_fail
+touch testsuite/reftests/label-text-shadow-changes-modify-clip.ui.known_fail
+
 cd "$olddir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/build/win32/Makefile.am
+++ b/build/win32/Makefile.am
@@ -28,11 +28,11 @@ endif
 
 SUBDIRS =	\
 	vs9 	\
-	vs10	\
-	vs11	\
-	vs12	\
-	vs14	\
-	vs15
+	vs10
+#	vs11	\
+#	vs12	\
+#	vs14	\
+#	vs15
 
 EXTRA_DIST +=	\
 	detectenv-msvc.mak		\

--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,10 @@ AC_ARG_ENABLE(xdamage,
               [AS_HELP_STRING([--enable-xdamage],
                               [support X Damage extension [default=maybe]])],,
               [enable_xdamage="maybe"])
+AC_ARG_ENABLE(egl-x11,
+              [AS_HELP_STRING([--enable-egl-x11],
+                              [Use EGL and XLib instead of GLX [default=no]])],,
+              [enable_egl_x11=no])
 
 AC_ARG_ENABLE(x11-backend,
               [AS_HELP_STRING([--enable-x11-backend],
@@ -1286,6 +1290,20 @@ if test "x$enable_x11_backend" = xyes; then
       AC_MSG_ERROR([Xdamage support requested but xdamage not found])
     fi
   fi
+
+  # Checks whether to use EGL-X11 or GLX
+
+  if test x"$enable_egl_x11" != xno; then
+    if $PKG_CONFIG --exists egl ; then
+      AC_DEFINE(HAVE_EGL_X11, 1, [Use EGL-X11 instead of GLX])
+
+      X_PACKAGES="$X_PACKAGES egl"
+    elif test x"$enable_egl_x11" = xyes; then
+      AC_MSG_ERROR([EGL-X11 support requested but egl not found])
+    fi
+  fi
+
+  AM_CONDITIONAL(USE_EGL_X11, test "x$enable_egl_x11" != xno)
 
   if $have_base_x_pc ; then
     GDK_EXTRA_LIBS="$x_extra_libs"

--- a/configure.ac
+++ b/configure.ac
@@ -1981,10 +1981,6 @@ build/win32/vs9/Makefile
 build/win32/vs9/gtk3-version-paths.vsprops
 build/win32/vs10/Makefile
 build/win32/vs10/gtk3-version-paths.props
-build/win32/vs11/Makefile
-build/win32/vs12/Makefile
-build/win32/vs14/Makefile
-build/win32/vs15/Makefile
 gdk/Makefile
 gdk/broadway/Makefile
 gdk/x11/Makefile

--- a/gdk/Makefile.am
+++ b/gdk/Makefile.am
@@ -243,8 +243,8 @@ if HAVE_INTROSPECTION
 introspection_files = 		\
 	$(filter-out gdkkeysyms-compat.h, $(gdk_h_sources))	\
 	$(gdk_c_sources)	\
-        gdkenumtypes.c		\
-        gdkenumtypes.h
+        $(srcdir)/gdkenumtypes.c	\
+        $(srcdir)/gdkenumtypes.h
 
 Gdk-3.0.gir: libgdk-3.la Makefile
 Gdk_3_0_gir_SCANNERFLAGS = 	\
@@ -408,7 +408,7 @@ endif
 
 lib_LTLIBRARIES = libgdk-3.la
 
-MAINTAINERCLEANFILES = $(gdk_built_sources) stamp-gdkenumtypes.h
+MAINTAINERCLEANFILES = $(gdk_built_sources)
 EXTRA_DIST += \
 	$(gdk_built_sources)	\
 	fallback-c89.c
@@ -422,18 +422,15 @@ BUILT_SOURCES = \
 	$(gdk_built_sources)			\
 	gdkconfig.h
 
-gdkenumtypes.h: stamp-gdkenumtypes.h
-	@true
-stamp-gdkenumtypes.h: $(gdk_h_sources) gdkenumtypes.h.template
+gdkenumtypes.h: $(gdk_public_h_sources) $(srcdir)/gdkenumtypes.h.template
 	$(AM_V_GEN) ( cd $(srcdir) && $(GLIB_MKENUMS) --template gdkenumtypes.h.template \
 		$(gdk_h_sources) ) >> xgen-geth \
-	&& (cmp -s xgen-geth gdkenumtypes.h || cp xgen-geth gdkenumtypes.h ) \
-	&& rm -f xgen-geth \
-	&& echo timestamp > $(@F)
+	&& (cmp -s xgen-geth gdkenumtypes.h || cp xgen-geth $(srcdir)/gdkenumtypes.h ) \
+	&& rm -f xgen-geth 
 gdkenumtypes.c: $(gdk_h_sources) gdkenumtypes.c.template
 	$(AM_V_GEN) ( cd $(srcdir) && $(GLIB_MKENUMS) --template gdkenumtypes.c.template \
 		$(gdk_h_sources) ) > xgen-getc \
-	&& cp xgen-getc gdkenumtypes.c  \
+	&& cp xgen-getc $(srcdir)/gdkenumtypes.c  \
 	&& rm -f xgen-getc
 
 #

--- a/gdk/gdkgl.c
+++ b/gdk/gdkgl.c
@@ -640,18 +640,6 @@ gdk_cairo_draw_from_gl (cairo_t              *cr,
   else
     {
       /* Software fallback */
-      int major, minor, version;
-
-      gdk_gl_context_get_version (paint_context, &major, &minor);
-      version = major * 100 + minor;
-
-      /* TODO: Use glTexSubImage2D() and do a row-by-row copy to replace
-       * the GL_UNPACK_ROW_LENGTH support
-       */
-      if (gdk_gl_context_get_use_es (paint_context) &&
-          !(version >= 300 || gdk_gl_context_has_unpack_subimage (paint_context)))
-        goto out;
-
       /* TODO: avoid reading back non-required data due to dest clip */
       image = cairo_surface_create_similar_image (cairo_get_target (cr),
                                                   (alpha_size == 0) ? CAIRO_FORMAT_RGB24 : CAIRO_FORMAT_ARGB32,
@@ -675,24 +663,15 @@ gdk_cairo_draw_from_gl (cairo_t              *cr,
                                      GL_TEXTURE_2D, source, 0);
         }
 
-      glPixelStorei (GL_PACK_ALIGNMENT, 4);
-      glPixelStorei (GL_PACK_ROW_LENGTH, cairo_image_surface_get_stride (image) / 4);
-
-      /* The implicit format conversion is going to make this path slower */
-      if (!gdk_gl_context_get_use_es (paint_context))
-        glReadPixels (x, y, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
-                      cairo_image_surface_get_data (image));
-      else
-        glReadPixels (x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
-                      cairo_image_surface_get_data (image));
-
-      glPixelStorei (GL_PACK_ROW_LENGTH, 0);
+      gdk_gl_context_download_texture (paint_context,
+                                       x, y, width, height,
+                                       image);
 
       glBindFramebufferEXT (GL_FRAMEBUFFER_EXT, 0);
 
       cairo_surface_mark_dirty (image);
 
-      /* Invert due to opengl having different origin */
+      /* Invert due to GL framebuffers having different origin */
       cairo_scale (cr, 1, -1);
       cairo_translate (cr, 0, -height / buffer_scale);
 
@@ -703,10 +682,8 @@ gdk_cairo_draw_from_gl (cairo_t              *cr,
       cairo_surface_destroy (image);
     }
 
-out:
   if (clip_region)
     cairo_region_destroy (clip_region);
-
 }
 
 /* This is always called with the paint context current */

--- a/gdk/gdkglcontext.c
+++ b/gdk/gdkglcontext.c
@@ -237,6 +237,57 @@ gdk_gl_context_get_property (GObject    *gobject,
 }
 
 void
+gdk_gl_context_download_texture (GdkGLContext    *context,
+                                 int              x,
+                                 int              y,
+                                 int              width,
+                                 int              height,
+                                 cairo_surface_t *image_surface)
+{
+  GdkGLContextPrivate *priv = gdk_gl_context_get_instance_private (context);
+
+  g_return_if_fail (GDK_IS_GL_CONTEXT (context));
+
+  /* GL_UNPACK_ROW_LENGTH is available on desktop GL, OpenGL ES >= 3.0, or if
+   * the GL_EXT_unpack_subimage extension for OpenGL ES 2.0 is available
+   */
+  if (!priv->use_es ||
+      (priv->use_es && (priv->gl_version >= 30 || priv->has_unpack_subimage)))
+    {
+      glPixelStorei (GL_PACK_ALIGNMENT, 4);
+      glPixelStorei (GL_PACK_ROW_LENGTH, cairo_image_surface_get_stride (image_surface) / 4);
+
+      if (priv->use_es)
+        glReadPixels (x, y, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                      cairo_image_surface_get_data (image_surface));
+      else
+        glReadPixels (x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
+                      cairo_image_surface_get_data (image_surface));
+
+      glPixelStorei (GL_PACK_ROW_LENGTH, 0);
+    }
+  else
+    {
+      GLvoid *data = cairo_image_surface_get_data (image_surface);
+      int stride = cairo_image_surface_get_stride (image_surface);
+      int i;
+
+      if (priv->use_es)
+        {
+          for (i = y; i < height; i++)
+            glReadPixels (x, i, width, 1, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                          (unsigned char *) data + (i * stride));
+        }
+      else
+        {
+          for (i = y; i < height; i++)
+            glReadPixels (x, i, width, 1, GL_RGBA, GL_UNSIGNED_BYTE,
+                          (unsigned char *) data + (i * stride));
+        }
+    }
+}
+
+void
 gdk_gl_context_upload_texture (GdkGLContext    *context,
                                cairo_surface_t *image_surface,
                                int              width,

--- a/gdk/gdkglcontextprivate.h
+++ b/gdk/gdkglcontextprivate.h
@@ -81,6 +81,12 @@ void                    gdk_gl_context_upload_texture           (GdkGLContext   
                                                                  int              width,
                                                                  int              height,
                                                                  guint            texture_target);
+void                    gdk_gl_context_download_texture         (GdkGLContext    *context,
+                                                                 int              x,
+                                                                 int              y,
+                                                                 int              width,
+                                                                 int              height,
+                                                                 cairo_surface_t *image_surface);
 GdkGLContextPaintData * gdk_gl_context_get_paint_data           (GdkGLContext    *context);
 gboolean                gdk_gl_context_use_texture_rectangle    (GdkGLContext    *context);
 gboolean                gdk_gl_context_has_framebuffer_blit     (GdkGLContext    *context);

--- a/gdk/gdkmonitor.c
+++ b/gdk/gdkmonitor.c
@@ -494,6 +494,25 @@ gdk_monitor_set_model (GdkMonitor *monitor,
 }
 
 void
+gdk_monitor_update_workarea (GdkMonitor *monitor)
+{
+  GdkRectangle workarea;
+  GdkScreen *screen;
+
+  /* screen will be NULL during initialization */
+  screen = gdk_display_get_default_screen (monitor->display);
+  if (!screen)
+    return;
+
+  gdk_monitor_get_workarea (monitor, &workarea);
+  if (gdk_rectangle_equal (&workarea, &monitor->workarea))
+    return;
+
+  monitor->workarea = workarea;
+  g_object_notify (G_OBJECT (monitor), "workarea");
+}
+
+void
 gdk_monitor_set_position (GdkMonitor *monitor,
                           int         x,
                           int         y)

--- a/gdk/gdkmonitorprivate.h
+++ b/gdk/gdkmonitorprivate.h
@@ -37,6 +37,7 @@ struct _GdkMonitor {
   char *manufacturer;
   char *model;
   GdkRectangle geometry;
+  GdkRectangle workarea;
   int width_mm;
   int height_mm;
   int scale_factor;
@@ -72,6 +73,7 @@ void            gdk_monitor_set_refresh_rate    (GdkMonitor *monitor,
                                                  int         refresh_rate);
 void            gdk_monitor_set_subpixel_layout (GdkMonitor        *monitor,
                                                  GdkSubpixelLayout  subpixel);
+void            gdk_monitor_update_workarea     (GdkMonitor *monitor);
 void            gdk_monitor_invalidate          (GdkMonitor *monitor);
 
 G_END_DECLS

--- a/gdk/x11/Makefile.am
+++ b/gdk/x11/Makefile.am
@@ -40,7 +40,6 @@ libgdk_x11_la_SOURCES = 	\
 	gdkeventtranslator.c	\
 	gdkeventtranslator.h	\
 	gdkgeometry-x11.c  	\
-	gdkglcontext-x11.c	\
 	gdkglcontext-x11.h	\
 	gdkkeys-x11.c		\
 	gdkmain-x11.c		\
@@ -60,6 +59,12 @@ libgdk_x11_la_SOURCES = 	\
 	gdkprivate-x11.h	\
 	xsettings-client.h	\
 	xsettings-client.c
+
+if USE_EGL_X11
+libgdk_x11_la_SOURCES += gdkglcontext-x11-eglx.c
+else
+libgdk_x11_la_SOURCES += gdkglcontext-x11.c
+endif
 
 libgdkinclude_HEADERS = 	\
 	gdkx.h

--- a/gdk/x11/gdkdisplay-x11.c
+++ b/gdk/x11/gdkdisplay-x11.c
@@ -614,6 +614,37 @@ get_event_xwindow (XEvent             *xevent)
   return xwindow;
 }
 
+static inline void
+gdk_check_window_unredirected (GdkDisplay     *display,
+                               GdkToplevelX11 *toplevel,
+                               GdkWindow      *window,
+                               Atom            property)
+{
+  Atom type = None;
+  gint format;
+  gulong nitems;
+  gulong bytes_after;
+  guchar *data;
+
+  gdk_x11_display_error_trap_push (display);
+  XGetWindowProperty (GDK_DISPLAY_XDISPLAY (display),
+                      GDK_WINDOW_XID (window),
+                      property,
+                      0, G_MAXLONG,
+                      False, XA_CARDINAL,
+                      &type, &format, &nitems,
+                      &bytes_after, &data);
+  gdk_x11_display_error_trap_pop_ignored (display);
+
+  if (type != None)
+    {
+      toplevel->unredirected = *((gint*)data) ? TRUE : FALSE;
+      XFree (data);
+    }
+  else
+    toplevel->unredirected = FALSE;
+}
+
 static gboolean
 gdk_x11_display_translate_event (GdkEventTranslator *translator,
                                  GdkDisplay         *display,
@@ -1067,6 +1098,9 @@ gdk_x11_display_translate_event (GdkEventTranslator *translator,
 	  if (xevent->xproperty.atom == gdk_x11_get_xatom_by_name_for_display (display, "_GTK_EDGE_CONSTRAINTS"))
 	    gdk_check_edge_constraints_changed (window);
 	}
+
+      if (toplevel && xevent->xproperty.atom == gdk_x11_get_xatom_by_name_for_display (display, "_GTK_WINDOW_UNREDIRECTED"))
+        gdk_check_window_unredirected (display, toplevel, window, xevent->xproperty.atom);
 
       if (window->event_mask & GDK_PROPERTY_CHANGE_MASK)
 	{

--- a/gdk/x11/gdkdisplay-x11.c
+++ b/gdk/x11/gdkdisplay-x11.c
@@ -1102,6 +1102,9 @@ gdk_x11_display_translate_event (GdkEventTranslator *translator,
       if (toplevel && xevent->xproperty.atom == gdk_x11_get_xatom_by_name_for_display (display, "_GTK_WINDOW_UNREDIRECTED"))
         gdk_check_window_unredirected (display, toplevel, window, xevent->xproperty.atom);
 
+      if (xevent->xproperty.atom == gdk_x11_get_xatom_by_name_for_display (display, "_NET_WORKAREA"))
+	_gdk_x11_screen_size_changed (screen, xevent);
+
       if (window->event_mask & GDK_PROPERTY_CHANGE_MASK)
 	{
 	  event->property.type = GDK_PROPERTY_NOTIFY;

--- a/gdk/x11/gdkdisplay-x11.h
+++ b/gdk/x11/gdkdisplay-x11.h
@@ -137,18 +137,19 @@ struct _GdkX11Display
 
   guint server_time_is_monotonic_time : 1;
 
-  guint have_glx : 1;
+  guint supports_gl : 1;
 
-  /* GLX extensions we check */
-  guint has_glx_swap_interval : 1;
-  guint has_glx_create_context : 1;
-  guint has_glx_texture_from_pixmap : 1;
-  guint has_glx_video_sync : 1;
-  guint has_glx_buffer_age : 1;
-  guint has_glx_sync_control : 1;
-  guint has_glx_multisample : 1;
-  guint has_glx_visual_rating : 1;
-  guint has_glx_create_es2_context : 1;
+  /* Platform-specific GL extensions we check */
+  guint has_swap_interval : 1;
+  guint has_create_context : 1;
+  guint has_texture_from_pixmap : 1;
+  guint has_video_sync : 1;
+  guint has_buffer_age : 1;
+  guint has_sync_control : 1;
+  guint has_multisample : 1;
+  guint has_visual_rating : 1;
+  guint has_create_es2_context : 1;
+  guint has_swap_buffers_with_damage : 1;
 };
 
 struct _GdkX11DisplayClass

--- a/gdk/x11/gdkdisplay-x11.h
+++ b/gdk/x11/gdkdisplay-x11.h
@@ -150,6 +150,7 @@ struct _GdkX11Display
   guint has_visual_rating : 1;
   guint has_create_es2_context : 1;
   guint has_swap_buffers_with_damage : 1;
+  guint has_image_pixmap : 1;
 };
 
 struct _GdkX11DisplayClass

--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -446,13 +446,14 @@ gdk_x11_gl_context_realize (GdkGLContext  *context,
   legacy_bit = !display_x11->has_create_context ||
                (_gdk_gl_flags & GDK_GL_LEGACY) != 0;
 
-  es_bit = ((_gdk_gl_flags & GDK_GL_GLES) != 0 ||
-            (share != NULL && gdk_gl_context_get_use_es (share)));
+  /* XXX: Force GLES */
+  es_bit =  TRUE;
 
   if (es_bit)
     {
+      /* XXX: Force GLES 2.0 */
       context_attrs[0] = EGL_CONTEXT_CLIENT_VERSION;
-      context_attrs[1] = major == 3 ? 3 : 2;
+      context_attrs[1] = 2;
       context_attrs[2] = EGL_NONE;
 
       eglBindAPI (EGL_OPENGL_ES_API);
@@ -490,7 +491,7 @@ gdk_x11_gl_context_realize (GdkGLContext  *context,
 
   GDK_NOTE (OPENGL,
             g_message ("Creating EGL context (version:%d.%d, debug:%s, forward:%s, legacy:%s, es:%s)",
-                       major, minor,
+                       2, 0,
                        debug_bit ? "yes" : "no",
                        compat_bit ? "yes" : "no",
                        legacy_bit ? "yes" : "no",
@@ -606,7 +607,7 @@ gdk_x11_display_init_gl (GdkDisplay *display)
   if (!eglInitialize (edpy, &major, &minor))
     return FALSE;
 
-  if (!eglBindAPI (EGL_OPENGL_API))
+  if (!eglBindAPI (EGL_OPENGL_ES_API))
     return FALSE;
 
   display_x11->supports_gl = TRUE;

--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -1,0 +1,865 @@
+/* GDK - The GIMP Drawing Kit
+ *
+ * gdkglcontext-x11.c: X11 specific OpenGL wrappers
+ *
+ * Copyright © 2014  Emmanuele Bassi
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "gdkglcontext-x11.h"
+#include "gdkdisplay-x11.h"
+#include "gdkscreen-x11.h"
+
+#include "gdkx11display.h"
+#include "gdkx11glcontext.h"
+#include "gdkx11screen.h"
+#include "gdkx11window.h"
+#include "gdkx11visual.h"
+#include "gdkvisualprivate.h"
+#include "gdkx11property.h"
+#include <X11/Xatom.h>
+
+#include "gdkinternals.h"
+
+#include "gdkintl.h"
+
+#include <cairo/cairo-xlib.h>
+
+#include <epoxy/egl.h>
+
+struct _GdkX11GLContext
+{
+  GdkGLContext parent_instance;
+
+  EGLDisplay egl_display;
+  EGLContext egl_context;
+  EGLConfig egl_config;
+
+  guint is_attached : 1;
+  guint do_frame_sync : 1;
+};
+
+struct _GdkX11GLContextClass
+{
+  GdkGLContextClass parent_class;
+};
+
+typedef struct {
+  EGLDisplay egl_display;
+  EGLConfig egl_config;
+  EGLSurface egl_surface;
+} DrawableInfo;
+
+static gboolean gdk_x11_display_init_gl (GdkDisplay *display);
+
+G_DEFINE_TYPE (GdkX11GLContext, gdk_x11_gl_context, GDK_TYPE_GL_CONTEXT)
+
+static EGLDisplay
+gdk_x11_display_get_egl_display (GdkDisplay *display)
+{
+  EGLDisplay dpy = NULL;
+
+  dpy = g_object_get_data (G_OBJECT (display), "-gdk-x11-egl-display");
+  if (dpy != NULL)
+    return dpy;
+
+  if (epoxy_has_egl_extension (NULL, "EGL_KHR_platform_base"))
+    {
+      PFNEGLGETPLATFORMDISPLAYPROC getPlatformDisplay =
+        (void *) eglGetProcAddress ("eglGetPlatformDisplay");
+
+      if (getPlatformDisplay)
+        dpy = getPlatformDisplay (EGL_PLATFORM_X11_KHR,
+                                  gdk_x11_display_get_xdisplay (display),
+                                  NULL);
+      if (dpy != NULL)
+        goto out;
+    }
+
+  if (epoxy_has_egl_extension (NULL, "EGL_EXT_platform_base"))
+    {
+      PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplay =
+        (void *) eglGetProcAddress ("eglGetPlatformDisplayEXT");
+
+      if (getPlatformDisplay)
+        dpy = getPlatformDisplay (EGL_PLATFORM_X11_EXT,
+                                  gdk_x11_display_get_xdisplay (display),
+                                  NULL);
+      if (dpy != NULL)
+        goto out;
+    }
+
+  dpy = eglGetDisplay ((EGLNativeDisplayType) gdk_x11_display_get_xdisplay (display));
+
+out:
+  if (dpy != NULL)
+    g_object_set_data (G_OBJECT (display), "-gdk-x11-egl-display", dpy);
+
+  return dpy;
+}
+
+typedef struct {
+  EGLDisplay egl_display;
+  EGLConfig egl_config;
+  EGLSurface egl_surface;
+
+  Display *xdisplay;
+  Window dummy_xwin;
+  XVisualInfo *xvisinfo;
+} DummyInfo;
+
+static void
+dummy_info_free (gpointer data)
+{
+  DummyInfo *info = data;
+
+  if (data == NULL)
+    return;
+
+  if (info->egl_surface != NULL)
+    {
+      eglDestroySurface (info->egl_display, info->egl_surface);
+      info->egl_surface = NULL;
+    }
+
+  if (info->dummy_xwin != None)
+    {
+      XDestroyWindow (info->xdisplay, info->dummy_xwin);
+      info->dummy_xwin = None;
+    }
+
+  if (info->xvisinfo != NULL)
+    {
+      XFree (info->xvisinfo);
+      info->xvisinfo = NULL;
+    }
+
+  g_slice_free (DummyInfo, info);
+}
+
+static XVisualInfo *
+get_visual_info_for_egl_config (GdkDisplay *display,
+                                EGLConfig   egl_config)
+{
+  XVisualInfo visinfo_template;
+  int template_mask = 0;
+  XVisualInfo *visinfo = NULL;
+  int visinfos_count;
+  EGLint visualid, red_size, green_size, blue_size, alpha_size;
+  EGLDisplay egl_display = gdk_x11_display_get_egl_display (display);
+
+  eglGetConfigAttrib (egl_display, egl_config, EGL_NATIVE_VISUAL_ID, &visualid);
+
+  if (visualid != 0)
+    {
+      visinfo_template.visualid = visualid;
+      template_mask |= VisualIDMask;
+    }
+  else
+    {
+      /* some EGL drivers don't implement the EGL_NATIVE_VISUAL_ID
+       * attribute, so attempt to find the closest match.
+       */
+
+      eglGetConfigAttrib (egl_display, egl_config, EGL_RED_SIZE, &red_size);
+      eglGetConfigAttrib (egl_display, egl_config, EGL_GREEN_SIZE, &green_size);
+      eglGetConfigAttrib (egl_display, egl_config, EGL_BLUE_SIZE, &blue_size);
+      eglGetConfigAttrib (egl_display, egl_config, EGL_ALPHA_SIZE, &alpha_size);
+
+      visinfo_template.depth = red_size + green_size + blue_size + alpha_size;
+      template_mask |= VisualDepthMask;
+
+      visinfo_template.screen = DefaultScreen (gdk_x11_display_get_xdisplay (display));
+      template_mask |= VisualScreenMask;
+    }
+
+  visinfo = XGetVisualInfo (gdk_x11_display_get_xdisplay (display),
+                            template_mask,
+                            &visinfo_template,
+                            &visinfos_count);
+
+  if (visinfos_count < 1)
+    return NULL;
+
+  return visinfo;
+}
+
+static EGLSurface
+gdk_x11_display_get_egl_dummy_surface (GdkDisplay *display,
+                                       EGLConfig   egl_config)
+{
+  DummyInfo *info;
+  XVisualInfo *xvisinfo;
+  XSetWindowAttributes attrs;
+
+  info = g_object_get_data (G_OBJECT (display), "-gdk-x11-egl-dummy-surface");
+  if (info != NULL)
+    return info->egl_surface;
+
+  xvisinfo = get_visual_info_for_egl_config (display, egl_config);
+  if (xvisinfo == NULL)
+    return NULL;
+
+  info = g_slice_new (DummyInfo);
+  info->xdisplay = gdk_x11_display_get_xdisplay (display);
+  info->xvisinfo = xvisinfo;
+  info->egl_display = gdk_x11_display_get_egl_display (display);
+  info->egl_config = egl_config;
+
+  attrs.override_redirect = True;
+  attrs.colormap = XCreateColormap (info->xdisplay,
+                                    DefaultRootWindow (info->xdisplay),
+                                    xvisinfo->visual,
+                                    AllocNone);
+  attrs.border_pixel = 0;
+
+  info->dummy_xwin =
+    XCreateWindow (info->xdisplay,
+                   DefaultRootWindow (info->xdisplay),
+                   -100, -100, 1, 1,
+                   0,
+                   xvisinfo->depth,
+                   CopyFromParent,
+                   xvisinfo->visual,
+                   CWOverrideRedirect | CWColormap | CWBorderPixel,
+                   &attrs);
+
+  info->egl_surface =
+    eglCreateWindowSurface (info->egl_display,
+                            info->egl_config,
+                            (EGLNativeWindowType) info->dummy_xwin,
+                            NULL);
+
+  g_object_set_data_full (G_OBJECT (display), "-gdk-x11-egl-dummy-surface",
+                          info,
+                          dummy_info_free);
+
+  return info->egl_surface;
+}
+
+static void
+drawable_info_free (gpointer data)
+{
+  DrawableInfo *info = data;
+
+  if (data == NULL)
+    return;
+
+  if (info->egl_surface != NULL)
+    {
+      eglDestroySurface (info->egl_display, info->egl_surface);
+      info->egl_surface = NULL;
+    }
+
+  g_slice_free (DrawableInfo, data);
+}
+
+static EGLSurface
+gdk_x11_window_get_egl_surface (GdkWindow *window,
+                                EGLConfig  config)
+{
+  GdkDisplay *display = gdk_window_get_display (window);
+  EGLDisplay egl_display = gdk_x11_display_get_egl_display (display);
+  DrawableInfo *info;
+
+  info = g_object_get_data (G_OBJECT (window), "-gdk-x11-egl-drawable");
+  if (info != NULL)
+    return info->egl_surface;
+
+  info = g_slice_new (DrawableInfo);
+  info->egl_display = egl_display;
+  info->egl_config = config;
+  info->egl_surface =
+    eglCreateWindowSurface (info->egl_display, config,
+                            (EGLNativeWindowType) gdk_x11_window_get_xid (window),
+                            NULL);
+
+  g_object_set_data_full (G_OBJECT (window), "-gdk-x11-egl-drawable",
+                          info,
+                          drawable_info_free);
+
+  return info->egl_surface;
+}
+
+void
+gdk_x11_window_invalidate_for_new_frame (GdkWindow      *window,
+                                         cairo_region_t *update_area)
+{
+  cairo_rectangle_int_t window_rect;
+  GdkDisplay *display = gdk_window_get_display (window);
+  GdkX11Display *display_x11 = GDK_X11_DISPLAY (display);
+  GdkX11GLContext *context_x11;
+  EGLint buffer_age;
+  gboolean invalidate_all;
+
+  /* Minimal update is ok if we're not drawing with gl */
+  if (window->gl_paint_context == NULL)
+    return;
+
+  context_x11 = GDK_X11_GL_CONTEXT (window->gl_paint_context);
+
+  buffer_age = 0;
+
+  if (display_x11->has_buffer_age)
+    {
+      gdk_gl_context_make_current (window->gl_paint_context);
+
+      eglQuerySurface (gdk_x11_display_get_egl_display (display),
+                       gdk_x11_window_get_egl_surface (window, context_x11->egl_config),
+                       EGL_BUFFER_AGE_EXT,
+                       &buffer_age);
+    }
+
+
+  invalidate_all = FALSE;
+  if (buffer_age == 0 || buffer_age >= 4)
+    {
+      invalidate_all = TRUE;
+    }
+  else
+    {
+      if (buffer_age >= 2)
+        {
+          if (window->old_updated_area[0])
+            cairo_region_union (update_area, window->old_updated_area[0]);
+          else
+            invalidate_all = TRUE;
+        }
+      if (buffer_age >= 3)
+        {
+          if (window->old_updated_area[1])
+            cairo_region_union (update_area, window->old_updated_area[1]);
+          else
+            invalidate_all = TRUE;
+        }
+    }
+
+  if (invalidate_all)
+    {
+      window_rect.x = 0;
+      window_rect.y = 0;
+      window_rect.width = gdk_window_get_width (window);
+      window_rect.height = gdk_window_get_height (window);
+
+      /* If nothing else is known, repaint everything so that the back
+         buffer is fully up-to-date for the swapbuffer */
+      cairo_region_union_rectangle (update_area, &window_rect);
+    }
+}
+
+static void
+gdk_x11_gl_context_end_frame (GdkGLContext   *context,
+                              cairo_region_t *painted,
+                              cairo_region_t *damage)
+{
+  GdkX11GLContext *context_x11 = GDK_X11_GL_CONTEXT (context);
+  GdkWindow *window = gdk_gl_context_get_window (context);
+  GdkDisplay *display = gdk_window_get_display (window);
+  EGLDisplay edpy = gdk_x11_display_get_egl_display (display);
+  EGLSurface esurface;
+
+  gdk_gl_context_make_current (context);
+
+  esurface = gdk_x11_window_get_egl_surface (window, context_x11->egl_config);
+
+  if (GDK_X11_DISPLAY (display)->has_swap_buffers_with_damage)
+    {
+      int i, j, n_rects = cairo_region_num_rectangles (damage);
+      int window_height = gdk_window_get_height (window);
+      gboolean free_rects = FALSE;
+      cairo_rectangle_int_t rect;
+      EGLint *rects;
+      
+      if (n_rects < 16)
+        rects = g_newa (EGLint, n_rects * 4);
+      else
+        {
+          rects = g_new (EGLint, n_rects * 4);
+          free_rects = TRUE;
+        }
+
+      for (i = 0, j = 0; i < n_rects; i++)
+        {
+          cairo_region_get_rectangle (damage, i, &rect);
+          rects[j++] = rect.x;
+          rects[j++] = window_height - rect.height - rect.y;
+          rects[j++] = rect.width;
+          rects[j++] = rect.height;
+        }
+
+      eglSwapBuffersWithDamageEXT (edpy, esurface, rects, n_rects);
+
+      if (free_rects)
+        g_free (rects);
+    }
+  else
+    eglSwapBuffers (edpy, esurface);
+}
+
+#define N_EGL_ATTRS 16
+
+static gboolean
+gdk_x11_gl_context_realize (GdkGLContext  *context,
+                            GError       **error)
+{
+  GdkX11Display *display_x11;
+  GdkDisplay *display;
+  GdkX11GLContext *context_x11;
+  GdkGLContext *share;
+  GdkWindow *window;
+  gboolean debug_bit, compat_bit, legacy_bit, es_bit;
+  int major, minor;
+  EGLint context_attrs[N_EGL_ATTRS];
+
+  window = gdk_gl_context_get_window (context);
+  display = gdk_window_get_display (window);
+
+  if (!gdk_x11_display_init_gl (display))
+    {
+      g_set_error_literal (error, GDK_GL_ERROR, GDK_GL_ERROR_NOT_AVAILABLE,
+                           _("No GL implementation available"));
+      return FALSE;
+    }
+
+  context_x11 = GDK_X11_GL_CONTEXT (context);
+  display_x11 = GDK_X11_DISPLAY (display);
+  share = gdk_gl_context_get_shared_context (context);
+
+  gdk_gl_context_get_required_version (context, &major, &minor);
+  debug_bit = gdk_gl_context_get_debug_enabled (context);
+  compat_bit = gdk_gl_context_get_forward_compatible (context);
+
+  legacy_bit = !display_x11->has_create_context ||
+               (_gdk_gl_flags & GDK_GL_LEGACY) != 0;
+
+  es_bit = ((_gdk_gl_flags & GDK_GL_GLES) != 0 ||
+            (share != NULL && gdk_gl_context_get_use_es (share)));
+
+  if (es_bit)
+    {
+      context_attrs[0] = EGL_CONTEXT_CLIENT_VERSION;
+      context_attrs[1] = major == 3 ? 3 : 2;
+      context_attrs[2] = EGL_NONE;
+
+      eglBindAPI (EGL_OPENGL_ES_API);
+    }
+  else
+    {
+      int flags = 0;
+
+      if (!display_x11->has_create_context)
+        {
+          context_attrs[0] = EGL_NONE;
+        }
+      else
+        {
+          if (debug_bit)
+            flags |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;
+          if (compat_bit)
+            flags |= EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE_BIT_KHR;
+
+          context_attrs[0] = EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR;
+          context_attrs[1] = legacy_bit
+                           ? EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR
+                           : EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR;
+          context_attrs[2] = EGL_CONTEXT_MAJOR_VERSION_KHR;
+          context_attrs[3] = legacy_bit ? 3 : major;
+          context_attrs[4] = EGL_CONTEXT_MINOR_VERSION_KHR;
+          context_attrs[5] = legacy_bit ? 0 : minor;
+          context_attrs[6] = EGL_CONTEXT_FLAGS_KHR;
+          context_attrs[7] = flags;
+          context_attrs[8] = EGL_NONE;
+        }
+
+      eglBindAPI (EGL_OPENGL_API);
+    }
+
+  GDK_NOTE (OPENGL,
+            g_message ("Creating EGL context (version:%d.%d, debug:%s, forward:%s, legacy:%s, es:%s)",
+                       major, minor,
+                       debug_bit ? "yes" : "no",
+                       compat_bit ? "yes" : "no",
+                       legacy_bit ? "yes" : "no",
+                       es_bit ? "yes" : "no"));
+
+  context_x11->egl_context =
+    eglCreateContext (gdk_x11_display_get_egl_display (display),
+                      context_x11->egl_config,
+                      share != NULL ? GDK_X11_GL_CONTEXT (share)->egl_context
+                                    : EGL_NO_CONTEXT,
+                      context_attrs);
+
+  /* If we're not asking for a GLES context, and we don't have the legacy bit set
+   * already, try again with a legacy context
+   */
+  if (context_x11->egl_context == NULL && !es_bit && !legacy_bit)
+    {
+      context_attrs[1] = EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR;
+      context_attrs[3] = 3;
+      context_attrs[5] = 0;
+
+      legacy_bit = TRUE;
+      es_bit = FALSE;
+
+      GDK_NOTE (OPENGL,
+                g_message ("Context creation failed; trying legacy EGL context"));
+
+      context_x11->egl_context =
+        eglCreateContext (gdk_x11_display_get_egl_display (display),
+                          context_x11->egl_config,
+                          share != NULL ? GDK_X11_GL_CONTEXT (share)->egl_context
+                                        : EGL_NO_CONTEXT,
+                          context_attrs);
+    }
+
+  if (context_x11->egl_context == NULL)
+    {
+      g_set_error_literal (error, GDK_GL_ERROR, GDK_GL_ERROR_NOT_AVAILABLE,
+                           _("Unable to create a GL context"));
+      return FALSE;
+    }
+
+  gdk_gl_context_set_is_legacy (context, legacy_bit);
+  gdk_gl_context_set_use_es (context, es_bit);
+
+  GDK_NOTE (OPENGL,
+            g_message ("Realized EGL context[%p]",
+                       context_x11->egl_context));
+
+  return TRUE;
+}
+
+static void
+gdk_x11_gl_context_dispose (GObject *gobject)
+{
+  GdkX11GLContext *context_x11 = GDK_X11_GL_CONTEXT (gobject);
+
+  if (context_x11->egl_context != NULL)
+    {
+      GdkGLContext *context = GDK_GL_CONTEXT (gobject);
+      GdkDisplay *display = gdk_gl_context_get_display (context);
+
+      if (eglGetCurrentContext () != context_x11->egl_context)
+        eglMakeCurrent (gdk_x11_display_get_egl_display (display),
+                        EGL_NO_SURFACE,
+                        EGL_NO_SURFACE,
+                        EGL_NO_CONTEXT);
+
+      GDK_NOTE (OPENGL, g_message ("Destroying EGL context"));
+      eglDestroyContext (gdk_x11_display_get_egl_display (display),
+                         context_x11->egl_context);
+      context_x11->egl_context = NULL;
+    }
+
+  G_OBJECT_CLASS (gdk_x11_gl_context_parent_class)->dispose (gobject);
+}
+
+static void
+gdk_x11_gl_context_class_init (GdkX11GLContextClass *klass)
+{
+  GdkGLContextClass *context_class = GDK_GL_CONTEXT_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  context_class->realize = gdk_x11_gl_context_realize;
+  context_class->end_frame = gdk_x11_gl_context_end_frame;
+
+  gobject_class->dispose = gdk_x11_gl_context_dispose;
+}
+
+static void
+gdk_x11_gl_context_init (GdkX11GLContext *self)
+{
+  self->do_frame_sync = TRUE;
+}
+
+static gboolean
+gdk_x11_display_init_gl (GdkDisplay *display)
+{
+  GdkX11Display *display_x11 = GDK_X11_DISPLAY (display);
+  EGLDisplay edpy;
+  int major, minor;
+
+  if (display_x11->supports_gl)
+    return TRUE;
+
+  if (_gdk_gl_flags & GDK_GL_DISABLE)
+    return FALSE;
+
+  edpy = gdk_x11_display_get_egl_display (display);
+  if (edpy == NULL)
+    return FALSE;
+
+  if (!eglInitialize (edpy, &major, &minor))
+    return FALSE;
+
+  if (!eglBindAPI (EGL_OPENGL_API))
+    return FALSE;
+
+  display_x11->supports_gl = TRUE;
+
+  display_x11->glx_version = major * 10 + minor;
+  display_x11->glx_error_base = 0; 
+  display_x11->glx_event_base = 0;
+
+  display_x11->has_create_context =
+    epoxy_has_egl_extension (edpy, "EGL_KHR_create_context");
+  display_x11->has_create_es2_context = FALSE;
+  display_x11->has_swap_interval = TRUE;
+  display_x11->has_texture_from_pixmap = FALSE;
+  display_x11->has_video_sync = FALSE;
+  display_x11->has_buffer_age =
+    epoxy_has_egl_extension (edpy, "EGL_EXT_buffer_age");
+  display_x11->has_sync_control = FALSE;
+  display_x11->has_multisample = FALSE;
+  display_x11->has_visual_rating = FALSE;
+  display_x11->has_swap_buffers_with_damage =
+    epoxy_has_egl_extension (edpy, "EGL_EXT_swap_buffers_with_damage");
+
+  GDK_NOTE (OPENGL,
+            g_message ("EGL X11 found\n"
+                       " - Vendor: %s\n"
+                       " - Version: %s\n"
+                       " - Client APIs: %s\n"
+                       " - Checked extensions:\n"
+                       "\t* EGL_KHR_create_context: %s\n"
+                       "\t* EGL_EXT_buffer_age: %s\n"
+                       "\t* EGL_EXT_swap_buffers_with_damage: %s",
+                       eglQueryString (edpy, EGL_VENDOR),
+                       eglQueryString (edpy, EGL_VERSION),
+                       eglQueryString (edpy, EGL_CLIENT_APIS),
+                       display_x11->has_create_context ? "yes" : "no",
+                       display_x11->has_buffer_age ? "yes" : "no",
+                       display_x11->has_swap_buffers_with_damage ? "yes" : "no"));
+
+  return TRUE;
+}
+
+void
+_gdk_x11_screen_update_visuals_for_gl (GdkScreen *screen)
+{
+  /* No-op; there's just no way to do the same trick we use
+   * with GLX to select an appropriate visual and cache it.
+   * For EGL-X11 we always pick the first visual and stick
+   * with it.
+   */
+}
+
+#define MAX_EGL_ATTRS 30
+
+static gboolean
+find_egl_config_for_window (GdkWindow  *window,
+                            EGLConfig  *config_out,
+                            GError    **error)
+{
+  GdkDisplay *display = gdk_window_get_display (window);
+  GdkVisual *visual = gdk_window_get_visual (window);
+  EGLint attrs[MAX_EGL_ATTRS];
+  EGLint count;
+  EGLDisplay egl_display;
+  EGLConfig *configs;
+  gboolean use_rgba;
+  int i = 0;
+
+  attrs[i++] = EGL_SURFACE_TYPE;
+  attrs[i++] = EGL_WINDOW_BIT;
+
+  attrs[i++] = EGL_COLOR_BUFFER_TYPE;
+  attrs[i++] = EGL_RGB_BUFFER;
+
+  attrs[i++] = EGL_RED_SIZE;
+  attrs[i++] = 1;
+  attrs[i++] = EGL_GREEN_SIZE;
+  attrs[i++] = 1;
+  attrs[i++] = EGL_BLUE_SIZE;
+  attrs[i++] = 1;
+
+  use_rgba = (visual == gdk_screen_get_rgba_visual (gdk_window_get_screen (window)));
+
+  if (use_rgba)
+    {
+      attrs[i++] = EGL_ALPHA_SIZE;
+      attrs[i++] = 1;
+    }
+  else
+    {
+      attrs[i++] = EGL_ALPHA_SIZE;
+      attrs[i++] = EGL_DONT_CARE;
+    }
+
+  attrs[i++] = EGL_NONE;
+  g_assert (i < MAX_EGL_ATTRS);
+
+  egl_display = gdk_x11_display_get_egl_display (display);
+  if (!eglChooseConfig (egl_display, attrs, NULL, 0, &count) || count < 1)
+    {
+      g_set_error_literal (error, GDK_GL_ERROR,
+                           GDK_GL_ERROR_UNSUPPORTED_FORMAT,
+                           _("No available configurations for the given pixel format"));
+      return FALSE;
+    }
+
+  configs = g_new (EGLConfig, count);
+  if (!eglChooseConfig (egl_display, attrs, configs, count, &count) || count < 1)
+    {
+      g_set_error_literal (error, GDK_GL_ERROR,
+                           GDK_GL_ERROR_UNSUPPORTED_FORMAT,
+                           _("No available configurations for the given pixel format"));
+      g_free (configs);
+      return FALSE;
+    }
+
+  if (config_out != NULL)
+    *config_out = configs[0];
+
+  g_free (configs);
+
+  return TRUE;
+}
+
+GdkGLContext *
+gdk_x11_window_create_gl_context (GdkWindow    *window,
+                                  gboolean      attached,
+                                  GdkGLContext *share,
+                                  GError      **error)
+{
+  GdkDisplay *display;
+  GdkX11GLContext *context;
+  EGLConfig config;
+
+  display = gdk_window_get_display (window);
+
+  if (!gdk_x11_display_init_gl (display))
+    {
+      g_set_error_literal (error, GDK_GL_ERROR,
+                           GDK_GL_ERROR_NOT_AVAILABLE,
+                           _("No GL implementation is available"));
+      return NULL;
+    }
+
+  if (!find_egl_config_for_window (window, &config, error))
+    return NULL;
+
+  context = g_object_new (GDK_TYPE_X11_GL_CONTEXT,
+                          "display", display,
+                          "window", window,
+                          "shared-context", share,
+                          NULL);
+
+  context->egl_config = config;
+  context->is_attached = attached;
+
+  return GDK_GL_CONTEXT (context);
+}
+
+gboolean
+gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
+                                         GdkGLContext *context)
+{
+  GdkX11GLContext *context_x11;
+  GdkWindow *window;
+  gboolean do_frame_sync = FALSE;
+  EGLSurface surface;
+  EGLDisplay egl_display;
+
+  egl_display = gdk_x11_display_get_egl_display (display);
+
+  if (context == NULL)
+    {
+      eglMakeCurrent (egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+      return TRUE;
+    }
+
+  window = gdk_gl_context_get_window (context);
+  context_x11 = GDK_X11_GL_CONTEXT (context);
+  if (context_x11->egl_context == NULL)
+    {
+      g_critical ("No EGL context associated to the GdkGLContext; you must "
+                  "call gdk_gl_context_realize() first.");
+      return FALSE;
+    }
+
+  GDK_NOTE (OPENGL,
+            g_message ("Making EGL context current"));
+
+  if (context_x11->is_attached)
+    surface = gdk_x11_window_get_egl_surface (window, context_x11->egl_config);
+  else
+    surface = gdk_x11_display_get_egl_dummy_surface (display, context_x11->egl_config);
+
+  if (!eglMakeCurrent (egl_display, surface, surface, context_x11->egl_context))
+    {
+      GDK_NOTE (OPENGL,
+                g_message ("Making EGL context current failed"));
+      return FALSE;
+    }
+
+  if (context_x11->is_attached)
+    {
+      /* If the WM is compositing there is no particular need to delay
+       * the swap when drawing on the offscreen, rendering to the screen
+       * happens later anyway, and its up to the compositor to sync that
+       * to the vblank. */
+      GdkScreen *screen = gdk_window_get_screen (window);
+
+      do_frame_sync = ! gdk_screen_is_composited (screen);
+
+      if (do_frame_sync != context_x11->do_frame_sync)
+        {
+          context_x11->do_frame_sync = do_frame_sync;
+
+          if (do_frame_sync)
+            eglSwapInterval (egl_display, 1);
+          else
+            eglSwapInterval (egl_display, 0);
+        }
+    }
+
+  return TRUE;
+}
+
+/**
+ * gdk_x11_display_get_glx_version:
+ * @display: a #GdkDisplay
+ * @major: (out): return location for the GLX major version
+ * @minor: (out): return location for the GLX minor version
+ *
+ * Retrieves the version of the GLX implementation.
+ *
+ * Returns: %TRUE if GLX is available
+ *
+ * Since: 3.16
+ */
+gboolean
+gdk_x11_display_get_glx_version (GdkDisplay *display,
+                                 gint       *major,
+                                 gint       *minor)
+{
+  g_return_val_if_fail (GDK_IS_DISPLAY (display), FALSE);
+
+  if (!GDK_IS_X11_DISPLAY (display))
+    return FALSE;
+
+  if (!gdk_x11_display_init_gl (display))
+    return FALSE;
+
+  if (major != NULL)
+    *major = GDK_X11_DISPLAY (display)->glx_version / 10;
+  if (minor != NULL)
+    *minor = GDK_X11_DISPLAY (display)->glx_version % 10;
+
+  return TRUE;
+}

--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -33,6 +33,10 @@
 #include "gdkx11property.h"
 #include <X11/Xatom.h>
 
+#ifdef HAVE_XCOMPOSITE
+#include <X11/extensions/Xcomposite.h>
+#endif
+
 #include "gdkinternals.h"
 
 #include "gdkintl.h"
@@ -873,6 +877,34 @@ gdk_x11_window_create_gl_context (GdkWindow    *window,
   return GDK_GL_CONTEXT (context);
 }
 
+#ifdef HAVE_XCOMPOSITE
+static gboolean
+window_is_composited (GdkDisplay *display,
+                      GdkWindow  *window)
+{
+  Display *dpy = GDK_DISPLAY_XDISPLAY (display);
+  Pixmap pixmap;
+
+  gdk_x11_display_error_trap_push (display);
+
+  /* This is kind of an expensive check, because there's no XComposite
+   * API to check if a Window has been unredirected. We check if there's
+   * a named Pixmap for it, and if we fail it means that the screen is
+   * not composited or the window is unredirected or not visible
+   */
+  pixmap = XCompositeNameWindowPixmap (dpy, GDK_WINDOW_XID (window));
+
+  XSync (GDK_DISPLAY_XDISPLAY (display), False);
+
+  if (gdk_x11_display_error_trap_pop (display))
+    return FALSE;
+
+  XFreePixmap (GDK_DISPLAY_XDISPLAY (display), pixmap);
+
+  return TRUE;
+}
+#endif /* HAVE_XCOMPOSITE */
+
 gboolean
 gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
                                          GdkGLContext *context)
@@ -917,13 +949,20 @@ gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
 
   if (context_x11->is_attached)
     {
-      /* If the WM is compositing there is no particular need to delay
-       * the swap when drawing on the offscreen, rendering to the screen
-       * happens later anyway, and its up to the compositor to sync that
-       * to the vblank. */
       GdkScreen *screen = gdk_window_get_screen (window);
+      gboolean is_composited = gdk_screen_is_composited (screen);
 
-      do_frame_sync = ! gdk_screen_is_composited (screen);
+#ifdef HAVE_XCOMPOSITE
+      /* If the WM is compositing and the window is redirected there is no
+       * particular need to delay the swap when drawing on the offscreen,
+       * rendering to the screen happens later anyway, and its up to the
+       * compositor to sync that to the vblank.
+       */
+      if (is_composited)
+        is_composited = window_is_composited (display, window->impl_window);
+#endif /* HAVE_XCOMPOSITE */
+
+      do_frame_sync = !is_composited;
 
       if (do_frame_sync != context_x11->do_frame_sync)
         {

--- a/gdk/x11/gdkglcontext-x11.c
+++ b/gdk/x11/gdkglcontext-x11.c
@@ -39,7 +39,28 @@
 
 #include <cairo/cairo-xlib.h>
 
+#include <epoxy/gl.h>
 #include <epoxy/glx.h>
+
+struct _GdkX11GLContext
+{
+  GdkGLContext parent_instance;
+
+  GLXContext glx_context;
+  GLXFBConfig glx_config;
+  GLXDrawable drawable;
+
+  guint is_attached : 1;
+  guint is_direct : 1;
+  guint do_frame_sync : 1;
+
+  guint do_blit_swap : 1;
+};
+
+struct _GdkX11GLContextClass
+{
+  GdkGLContextClass parent_class;
+};
 
 G_DEFINE_TYPE (GdkX11GLContext, gdk_x11_gl_context, GDK_TYPE_GL_CONTEXT)
 
@@ -47,9 +68,9 @@ typedef struct {
   GdkDisplay *display;
 
   GLXDrawable glx_drawable;
+  GLXWindow dummy_glx;
 
   Window dummy_xwin;
-  GLXWindow dummy_glx;
 
   guint32 last_frame_counter;
 } DrawableInfo;
@@ -100,7 +121,7 @@ maybe_wait_for_vblank (GdkDisplay  *display,
   GdkX11Display *display_x11 = GDK_X11_DISPLAY (display);
   Display *dpy = gdk_x11_display_get_xdisplay (display);
 
-  if (display_x11->has_glx_sync_control)
+  if (display_x11->has_sync_control)
     {
       gint64 ust, msc, sbc;
 
@@ -109,7 +130,7 @@ maybe_wait_for_vblank (GdkDisplay  *display,
                         0, 2, (msc + 1) % 2,
                         &ust, &msc, &sbc);
     }
-  else if (display_x11->has_glx_video_sync)
+  else if (display_x11->has_video_sync)
     {
       guint32 current_count;
 
@@ -140,7 +161,7 @@ gdk_x11_window_invalidate_for_new_frame (GdkWindow      *window,
 
   context_x11->do_blit_swap = FALSE;
 
-  if (display_x11->has_glx_buffer_age)
+  if (display_x11->has_buffer_age)
     {
       gdk_gl_context_make_current (window->gl_paint_context);
       glXQueryDrawable(dpy, context_x11->drawable,
@@ -248,13 +269,13 @@ gdk_x11_gl_context_end_frame (GdkGLContext *context,
   if (context_x11->do_frame_sync)
     {
       guint32 end_frame_counter = 0;
-      gboolean has_counter = display_x11->has_glx_video_sync;
-      gboolean can_wait = display_x11->has_glx_video_sync || display_x11->has_glx_sync_control;
+      gboolean has_counter = display_x11->has_video_sync;
+      gboolean can_wait = display_x11->has_video_sync || display_x11->has_sync_control;
 
-      if (display_x11->has_glx_video_sync)
+      if (display_x11->has_video_sync)
         glXGetVideoSyncSGI (&end_frame_counter);
 
-      if (context_x11->do_frame_sync && !display_x11->has_glx_swap_interval)
+      if (context_x11->do_frame_sync && !display_x11->has_swap_interval)
         {
           glFinish ();
 
@@ -284,7 +305,7 @@ gdk_x11_gl_context_end_frame (GdkGLContext *context,
   else
     glXSwapBuffers (dpy, drawable);
 
-  if (context_x11->do_frame_sync && info != NULL && display_x11->has_glx_video_sync)
+  if (context_x11->do_frame_sync && info != NULL && display_x11->has_video_sync)
     glXGetVideoSyncSGI (&info->last_frame_counter);
 }
 
@@ -439,7 +460,7 @@ gdk_x11_gl_context_texture_from_surface (GdkGLContext *paint_context,
   GdkX11Display *display_x11;
 
   display_x11 = GDK_X11_DISPLAY (gdk_gl_context_get_display (paint_context));
-  if (!display_x11->has_glx_texture_from_pixmap)
+  if (!display_x11->has_texture_from_pixmap)
     return FALSE;
 
   if (cairo_surface_get_type (surface) != CAIRO_SURFACE_TYPE_XLIB)
@@ -640,12 +661,12 @@ gdk_x11_gl_context_realize (GdkGLContext  *context,
   compat_bit = gdk_gl_context_get_forward_compatible (context);
 
   /* If there is no glXCreateContextAttribsARB() then we default to legacy */
-  legacy_bit = !display_x11->has_glx_create_context ||
+  legacy_bit = !display_x11->has_create_context ||
                (_gdk_gl_flags & GDK_GL_LEGACY) != 0;
 
   es_bit = ((_gdk_gl_flags & GDK_GL_GLES) != 0 ||
             (share != NULL && gdk_gl_context_get_use_es (share))) &&
-           (display_x11->has_glx_create_context && display_x11->has_glx_create_es2_context);
+           (display_x11->has_create_context && display_x11->has_create_es2_context);
 
   /* We cannot share legacy contexts with core profile ones, so the
    * shared context is the one that decides if we're going to create
@@ -672,7 +693,7 @@ gdk_x11_gl_context_realize (GdkGLContext  *context,
    * a compatibility profile; if we don't, then we have to fall back to the
    * old GLX 1.3 API.
    */
-  if (legacy_bit && !GDK_X11_DISPLAY (display)->has_glx_create_context)
+  if (legacy_bit && !GDK_X11_DISPLAY (display)->has_create_context)
     {
       GDK_NOTE (OPENGL, g_message ("Creating legacy GL context on request"));
       context_x11->glx_context = create_legacy_context (display, context_x11->glx_config, share);
@@ -848,7 +869,7 @@ gdk_x11_screen_init_gl (GdkScreen *screen)
   int error_base, event_base;
   int screen_num;
 
-  if (display_x11->have_glx)
+  if (display_x11->supports_gl)
     return TRUE;
 
   if (_gdk_gl_flags & GDK_GL_DISABLE)
@@ -887,29 +908,29 @@ gdk_x11_screen_init_gl (GdkScreen *screen)
 
   screen_num = GDK_X11_SCREEN (screen)->screen_num;
 
-  display_x11->have_glx = TRUE;
+  display_x11->supports_gl = TRUE;
 
   display_x11->glx_version = epoxy_glx_version (dpy, screen_num);
   display_x11->glx_error_base = error_base;
   display_x11->glx_event_base = event_base;
 
-  display_x11->has_glx_create_context =
+  display_x11->has_create_context =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_ARB_create_context_profile");
-  display_x11->has_glx_create_es2_context =
+  display_x11->has_create_es2_context =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_EXT_create_context_es2_profile");
-  display_x11->has_glx_swap_interval =
+  display_x11->has_swap_interval =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_SGI_swap_control");
-  display_x11->has_glx_texture_from_pixmap =
+  display_x11->has_texture_from_pixmap =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_EXT_texture_from_pixmap");
-  display_x11->has_glx_video_sync =
+  display_x11->has_video_sync =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_SGI_video_sync");
-  display_x11->has_glx_buffer_age =
+  display_x11->has_buffer_age =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_EXT_buffer_age");
-  display_x11->has_glx_sync_control =
+  display_x11->has_sync_control =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_OML_sync_control");
-  display_x11->has_glx_multisample =
+  display_x11->has_multisample =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_ARB_multisample");
-  display_x11->has_glx_visual_rating =
+  display_x11->has_visual_rating =
     epoxy_has_glx_extension (dpy, screen_num, "GLX_EXT_visual_rating");
 
   GDK_NOTE (OPENGL,
@@ -926,13 +947,13 @@ gdk_x11_screen_init_gl (GdkScreen *screen)
                      display_x11->glx_version / 10,
                      display_x11->glx_version % 10,
                      glXGetClientString (dpy, GLX_VENDOR),
-                     display_x11->has_glx_create_context ? "yes" : "no",
-                     display_x11->has_glx_create_es2_context ? "yes" : "no",
-                     display_x11->has_glx_swap_interval ? "yes" : "no",
-                     display_x11->has_glx_texture_from_pixmap ? "yes" : "no",
-                     display_x11->has_glx_video_sync ? "yes" : "no",
-                     display_x11->has_glx_buffer_age ? "yes" : "no",
-                     display_x11->has_glx_sync_control ? "yes" : "no"));
+                     display_x11->has_create_context ? "yes" : "no",
+                     display_x11->has_create_es2_context ? "yes" : "no",
+                     display_x11->has_swap_interval ? "yes" : "no",
+                     display_x11->has_texture_from_pixmap ? "yes" : "no",
+                     display_x11->has_video_sync ? "yes" : "no",
+                     display_x11->has_buffer_age ? "yes" : "no",
+                     display_x11->has_sync_control ? "yes" : "no"));
 
   return TRUE;
 }
@@ -1258,10 +1279,10 @@ _gdk_x11_screen_update_visuals_for_gl (GdkScreen *screen)
       glXGetConfig (dpy, &visual_list[0], GLX_DEPTH_SIZE, &gl_info[i].depth_size);
       glXGetConfig (dpy, &visual_list[0], GLX_STENCIL_SIZE, &gl_info[i].stencil_size);
 
-      if (display_x11->has_glx_multisample)
+      if (display_x11->has_multisample)
         glXGetConfig(dpy, &visual_list[0], GLX_SAMPLE_BUFFERS_ARB, &gl_info[i].num_multisample);
 
-      if (display_x11->has_glx_visual_rating)
+      if (display_x11->has_visual_rating)
         glXGetConfig(dpy, &visual_list[0], GLX_VISUAL_CAVEAT_EXT, &gl_info[i].visual_caveat);
       else
         gl_info[i].visual_caveat = GLX_NONE_EXT;
@@ -1353,7 +1374,7 @@ gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
       return FALSE;
     }
 
-  if (context_x11->is_attached && GDK_X11_DISPLAY (display)->has_glx_swap_interval)
+  if (context_x11->is_attached && GDK_X11_DISPLAY (display)->has_swap_interval)
     {
       window = gdk_gl_context_get_window (context);
 

--- a/gdk/x11/gdkglcontext-x11.h
+++ b/gdk/x11/gdkglcontext-x11.h
@@ -24,9 +24,6 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 
-#include <epoxy/gl.h>
-#include <epoxy/glx.h>
-
 #include "gdkglcontextprivate.h"
 #include "gdkdisplayprivate.h"
 #include "gdkvisual.h"
@@ -36,27 +33,6 @@
 
 G_BEGIN_DECLS
 
-struct _GdkX11GLContext
-{
-  GdkGLContext parent_instance;
-
-  GLXContext glx_context;
-  GLXFBConfig glx_config;
-  GLXDrawable drawable;
-
-  guint is_attached : 1;
-  guint is_direct : 1;
-  guint do_frame_sync : 1;
-
-  guint do_blit_swap : 1;
-};
-
-struct _GdkX11GLContextClass
-{
-  GdkGLContextClass parent_class;
-};
-
-gboolean        gdk_x11_screen_init_gl                          (GdkScreen         *screen);
 GdkGLContext *  gdk_x11_window_create_gl_context                (GdkWindow         *window,
 								 gboolean           attached,
                                                                  GdkGLContext      *share,

--- a/gdk/x11/gdkscreen-x11.c
+++ b/gdk/x11/gdkscreen-x11.c
@@ -1002,7 +1002,7 @@ init_randr_support (GdkScreen *screen)
   /* NB: This is also needed for XSettings, so don't remove. */
   XSelectInput (GDK_SCREEN_XDISPLAY (screen),
                 x11_screen->xroot_window,
-                StructureNotifyMask);
+                StructureNotifyMask | PropertyChangeMask);
 
 #ifdef HAVE_RANDR
   if (!GDK_X11_DISPLAY (gdk_screen_get_display (screen))->have_randr12)

--- a/gdk/x11/gdkscreen-x11.c
+++ b/gdk/x11/gdkscreen-x11.c
@@ -515,7 +515,7 @@ init_randr15 (GdkScreen *screen, gboolean *changed)
 
       gdk_monitor_set_position (GDK_MONITOR (monitor), newgeo.x, newgeo.y);
       gdk_monitor_set_size (GDK_MONITOR (monitor), newgeo.width, newgeo.height);
-      g_object_notify (G_OBJECT (monitor), "workarea");
+      gdk_monitor_update_workarea (GDK_MONITOR (monitor));
       gdk_monitor_set_physical_size (GDK_MONITOR (monitor),
                                      rr_monitors[i].mwidth,
                                      rr_monitors[i].mheight);
@@ -695,7 +695,7 @@ init_randr13 (GdkScreen *screen, gboolean *changed)
 
           gdk_monitor_set_position (GDK_MONITOR (monitor), newgeo.x, newgeo.y);
           gdk_monitor_set_size (GDK_MONITOR (monitor), newgeo.width, newgeo.height);
-          g_object_notify (G_OBJECT (monitor), "workarea");
+          gdk_monitor_update_workarea (GDK_MONITOR (monitor));
           gdk_monitor_set_physical_size (GDK_MONITOR (monitor),
                                          output_info->mm_width,
                                          output_info->mm_height);
@@ -835,7 +835,7 @@ init_no_multihead (GdkScreen *screen, gboolean *changed)
   gdk_monitor_set_position (GDK_MONITOR (monitor), newgeo.x, newgeo.y);
   gdk_monitor_set_size (GDK_MONITOR (monitor), newgeo.width, newgeo.height);
 
-  g_object_notify (G_OBJECT (monitor), "workarea");
+  gdk_monitor_update_workarea (GDK_MONITOR (monitor));
   gdk_monitor_set_physical_size (GDK_MONITOR (monitor),
                                  gdk_x11_screen_get_width_mm (screen),
                                  gdk_x11_screen_get_height_mm (screen));

--- a/gdk/x11/gdkscreen-x11.h
+++ b/gdk/x11/gdkscreen-x11.h
@@ -46,6 +46,8 @@ struct _GdkX11Screen
   gint width;
   gint height;
 
+  GdkRectangle workarea;
+
   gint window_scale;
   gboolean fixed_window_scale;
 

--- a/gdk/x11/gdkwindow-x11.h
+++ b/gdk/x11/gdkwindow-x11.h
@@ -147,6 +147,7 @@ struct _GdkToplevelX11
    * to the extended update counter */
   guint pending_counter_value_is_extended : 1;
   guint configure_counter_value_is_extended : 1;
+  guint unredirected : 1;       /* _GTK_WINDOW_UNREDIRECTED */
 
   gulong map_serial;	/* Serial of last transition from unmapped */
   

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -1340,6 +1340,7 @@ adwaita_theme_scss = \
 	theme/Adwaita/_colors.scss 		\
 	theme/Adwaita/_common.scss 		\
 	theme/Adwaita/_drawing.scss 		\
+	theme/Adwaita/_endless.scss 		\
 	theme/Adwaita/gtk-contained-dark.scss 	\
 	theme/Adwaita/gtk-contained.scss 	\
 	$()

--- a/gtk/gtkfilechooserwidget.c
+++ b/gtk/gtkfilechooserwidget.c
@@ -2570,7 +2570,7 @@ location_entry_setup (GtkFileChooserWidget *impl)
   _gtk_file_chooser_entry_set_action (GTK_FILE_CHOOSER_ENTRY (priv->location_entry), priv->action);
   _gtk_file_chooser_entry_set_file_filter (GTK_FILE_CHOOSER_ENTRY (priv->location_entry),
                                            priv->current_filter);
-  gtk_entry_set_width_chars (GTK_ENTRY (priv->location_entry), 45);
+  gtk_entry_set_width_chars (GTK_ENTRY (priv->location_entry), 30);
   gtk_entry_set_activates_default (GTK_ENTRY (priv->location_entry), TRUE);
 }
 

--- a/gtk/gtkfilechooserwidget.c
+++ b/gtk/gtkfilechooserwidget.c
@@ -60,6 +60,7 @@
 #include "gtksizegroup.h"
 #include "gtksizerequest.h"
 #include "gtkstack.h"
+#include "gtktogglebutton.h"
 #include "gtktooltip.h"
 #include "gtktreednd.h"
 #include "gtktreeprivate.h"
@@ -240,6 +241,7 @@ struct _GtkFileChooserWidgetPrivate {
   GtkWidget *browse_new_folder_button;
   GtkSizeGroup *browse_path_bar_size_group;
   GtkWidget *browse_path_bar;
+  GtkWidget *browse_places_button;
   GtkWidget *new_folder_name_entry;
   GtkWidget *new_folder_create_button;
   GtkWidget *new_folder_error_label;
@@ -256,6 +258,7 @@ struct _GtkFileChooserWidgetPrivate {
   char *browse_files_last_selected_name;
 
   GtkWidget *places_sidebar;
+  GtkWidget *places_sidebar_box;
   GtkWidget *places_view;
   StartupMode startup_mode;
 
@@ -4013,6 +4016,37 @@ add_cwd_to_sidebar_if_needed (GtkFileChooserWidget *impl)
   g_object_unref (cwd_file);
 }
 
+static void
+browse_places_button_changed_cb (GtkFileChooserWidget *impl)
+{
+  gboolean active;
+  GtkFileChooserWidgetPrivate *priv = impl->priv;
+
+  active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (priv->browse_places_button));
+  /* FIXME: using a GtkBox to hide the GtkPlacesSidebar because it uses show_all on itself */
+  gtk_widget_set_visible (priv->places_sidebar_box, active);
+}
+
+static void
+show_places_button_if_needed (GtkFileChooserWidget *impl)
+{
+  gint sidebar_width;
+  GdkScreen *screen;
+  GtkFileChooserWidgetPrivate *priv = impl->priv;
+
+  screen = gtk_widget_get_screen (GTK_WIDGET (impl));
+  if (!screen)
+    return;
+
+  /* If the sidebar width takes more than 25% of the screen width, hide it */
+  sidebar_width = gtk_widget_get_allocated_width (priv->places_sidebar);
+  if (gdk_screen_get_width (screen) > sidebar_width * 4)
+    return;
+
+  gtk_widget_set_visible (priv->browse_places_button, TRUE);
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (priv->browse_places_button), FALSE);
+}
+
 /* GtkWidget::map method */
 static void
 gtk_file_chooser_widget_map (GtkWidget *widget)
@@ -4027,6 +4061,7 @@ gtk_file_chooser_widget_map (GtkWidget *widget)
   settings_load (impl);
 
   add_cwd_to_sidebar_if_needed (impl);
+  show_places_button_if_needed (impl);
 
   if (priv->operation_mode == OPERATION_MODE_BROWSE)
     {
@@ -8446,6 +8481,7 @@ gtk_file_chooser_widget_class_init (GtkFileChooserWidgetClass *class)
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_widgets_hpaned);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_files_stack);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, places_sidebar);
+  gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, places_sidebar_box);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, places_view);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_files_tree_view);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_files_swin);
@@ -8454,6 +8490,7 @@ gtk_file_chooser_widget_class_init (GtkFileChooserWidgetClass *class)
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_new_folder_button);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_path_bar_size_group);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_path_bar);
+  gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, browse_places_button);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, filter_combo_hbox);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, filter_combo);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, preview_box);
@@ -8484,6 +8521,7 @@ gtk_file_chooser_widget_class_init (GtkFileChooserWidgetClass *class)
 
   /* And a *lot* of callbacks to bind ... */
   gtk_widget_class_bind_template_callback (widget_class, browse_files_key_press_event_cb);
+  gtk_widget_class_bind_template_callback (widget_class, browse_places_button_changed_cb);
   gtk_widget_class_bind_template_callback (widget_class, file_list_drag_drop_cb);
   gtk_widget_class_bind_template_callback (widget_class, file_list_drag_data_received_cb);
   gtk_widget_class_bind_template_callback (widget_class, list_popup_menu_cb);

--- a/gtk/gtkfilechooserwidget.c
+++ b/gtk/gtkfilechooserwidget.c
@@ -6158,6 +6158,31 @@ find_good_size_from_style (GtkWidget *widget,
 }
 
 static void
+_gtk_file_chooser_get_monitor_workarea_for_widget (GtkWidget *widget,
+                                                   gint      *width,
+                                                   gint      *height)
+{
+  gint monitor_num;
+  GdkScreen *screen;
+  GdkWindow *window;
+  GdkRectangle monitor;
+
+  screen = gtk_widget_get_screen (widget);
+  window = gtk_widget_get_window (widget);
+  if (!screen || !window)
+    {
+      *width = 1920;
+      *height = 1080;
+      return;
+    }
+
+  monitor_num = gdk_screen_get_monitor_at_window (screen, window);
+  gdk_screen_get_monitor_workarea (screen, monitor_num, &monitor);
+  *width = monitor.width;
+  *height = monitor.height;
+}
+
+static void
 gtk_file_chooser_widget_get_default_size (GtkFileChooserEmbed *chooser_embed,
                                           gint                *default_width,
                                           gint                *default_height)
@@ -6165,15 +6190,20 @@ gtk_file_chooser_widget_get_default_size (GtkFileChooserEmbed *chooser_embed,
   GtkFileChooserWidget *impl = GTK_FILE_CHOOSER_WIDGET (chooser_embed);
   GtkFileChooserWidgetPrivate *priv = impl->priv;
   GtkRequisition req;
-  int x, y, width, height;
+  int x, y, width, height, max_width, max_height;
   GSettings *settings;
+
+  _gtk_file_chooser_get_monitor_workarea_for_widget (GTK_WIDGET (impl), &max_width, &max_height);
+  max_width = max_width * 7 / 8;
+  max_height = max_height * 7 / 8;
 
   settings = _gtk_file_chooser_get_settings_for_widget (GTK_WIDGET (impl));
 
   g_settings_get (settings, SETTINGS_KEY_WINDOW_POSITION, "(ii)", &x, &y);
   g_settings_get (settings, SETTINGS_KEY_WINDOW_SIZE, "(ii)", &width, &height);
 
-  if (x >= 0 && y >= 0 && width > 0 && height > 0)
+  if (x >= 0 && y >= 0 && width > 0 && height > 0 &&
+      width <= max_width && height <= max_height)
     {
       *default_width = width;
       *default_height = height;
@@ -6198,6 +6228,10 @@ gtk_file_chooser_widget_get_default_size (GtkFileChooserEmbed *chooser_embed,
                                      &req, NULL);
       *default_height += gtk_box_get_spacing (GTK_BOX (chooser_embed)) + req.height;
     }
+
+  /* Make sure it will fit in the screen */
+  *default_width = MIN (*default_width, max_width);
+  *default_height = MIN (*default_height, max_height);
 }
 
 struct switch_folder_closure {

--- a/gtk/gtkfilechooserwidget.c
+++ b/gtk/gtkfilechooserwidget.c
@@ -72,6 +72,7 @@
 #include "gtkshow.h"
 #include "gtkmain.h"
 #include "gtkscrollable.h"
+#include "gtkscrolledwindow.h"
 #include "gtkpopover.h"
 #include "gtkrevealer.h"
 #include "gtkspinner.h"
@@ -277,6 +278,7 @@ struct _GtkFileChooserWidgetPrivate {
   guint load_recent_id;
 
   GtkWidget *extra_and_filters;
+  GtkWidget *extra_and_filters_scroll;
   GtkWidget *filter_combo_hbox;
   GtkWidget *filter_combo;
   GtkWidget *preview_box;
@@ -4045,6 +4047,23 @@ show_places_button_if_needed (GtkFileChooserWidget *impl)
 
   gtk_widget_set_visible (priv->browse_places_button, TRUE);
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (priv->browse_places_button), FALSE);
+}
+
+static void
+extra_and_filters_size_allocate_cb (GtkFileChooserWidget *impl)
+{
+  GdkScreen *screen;
+  GtkFileChooserWidgetPrivate *priv = impl->priv;
+
+  screen = gtk_widget_get_screen (GTK_WIDGET (impl));
+  if (!screen)
+    return;
+  if (gdk_screen_get_width (screen) >= gtk_widget_get_allocated_width (priv->extra_and_filters))
+    return;
+
+  gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (priv->extra_and_filters_scroll),
+                                  GTK_POLICY_ALWAYS,
+                                  GTK_POLICY_NEVER);
 }
 
 /* GtkWidget::map method */
@@ -8496,6 +8515,7 @@ gtk_file_chooser_widget_class_init (GtkFileChooserWidgetClass *class)
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, preview_box);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, extra_align);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, extra_and_filters);
+  gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, extra_and_filters_scroll);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, location_entry_box);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, search_entry);
   gtk_widget_class_bind_template_child_private (widget_class, GtkFileChooserWidget, search_spinner);
@@ -8546,6 +8566,7 @@ gtk_file_chooser_widget_class_init (GtkFileChooserWidgetClass *class)
   gtk_widget_class_bind_template_callback (widget_class, rename_file_name_changed);
   gtk_widget_class_bind_template_callback (widget_class, rename_file_rename_clicked);
   gtk_widget_class_bind_template_callback (widget_class, rename_file_end);
+  gtk_widget_class_bind_template_callback (widget_class, extra_and_filters_size_allocate_cb);
 
   gtk_widget_class_set_css_name (widget_class, "filechooser");
 }

--- a/gtk/gtkglarea.c
+++ b/gtk/gtkglarea.c
@@ -460,7 +460,7 @@ gtk_gl_area_allocate_buffers (GtkGLArea *area)
       glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
       if (gdk_gl_context_get_use_es (priv->context))
-        glTexImage2D (GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+        glTexImage2D (GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
       else
         glTexImage2D (GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
     }

--- a/gtk/gtkglarea.c
+++ b/gtk/gtkglarea.c
@@ -390,7 +390,7 @@ gtk_gl_area_ensure_buffers (GtkGLArea *area)
 
   priv->have_buffers = TRUE;
 
-  glGenFramebuffersEXT (1, &priv->frame_buffer);
+  glGenFramebuffers (1, &priv->frame_buffer);
 
   if (priv->has_alpha)
     {
@@ -401,7 +401,7 @@ gtk_gl_area_ensure_buffers (GtkGLArea *area)
       /* Delete old render buffer if any */
       if (priv->render_buffer != 0)
         {
-          glDeleteRenderbuffersEXT(1, &priv->render_buffer);
+          glDeleteRenderbuffers(1, &priv->render_buffer);
           priv->render_buffer = 0;
         }
     }
@@ -409,7 +409,7 @@ gtk_gl_area_ensure_buffers (GtkGLArea *area)
     {
     /* For non-alpha we use render buffers so we can blit instead of texture the result */
       if (priv->render_buffer == 0)
-        glGenRenderbuffersEXT (1, &priv->render_buffer);
+        glGenRenderbuffers (1, &priv->render_buffer);
 
       /* Delete old texture if any */
       if (priv->texture != 0)
@@ -422,12 +422,12 @@ gtk_gl_area_ensure_buffers (GtkGLArea *area)
   if ((priv->has_depth_buffer || priv->has_stencil_buffer))
     {
       if (priv->depth_stencil_buffer == 0)
-        glGenRenderbuffersEXT (1, &priv->depth_stencil_buffer);
+        glGenRenderbuffers (1, &priv->depth_stencil_buffer);
     }
   else if (priv->depth_stencil_buffer != 0)
     {
       /* Delete old depth/stencil buffer */
-      glDeleteRenderbuffersEXT (1, &priv->depth_stencil_buffer);
+      glDeleteRenderbuffers (1, &priv->depth_stencil_buffer);
       priv->depth_stencil_buffer = 0;
     }
 
@@ -514,23 +514,23 @@ gtk_gl_area_attach_buffers (GtkGLArea *area)
   else if (priv->needs_resize)
     gtk_gl_area_allocate_buffers (area);
 
-  glBindFramebufferEXT (GL_FRAMEBUFFER_EXT, priv->frame_buffer);
+  glBindFramebuffer (GL_FRAMEBUFFER, priv->frame_buffer);
 
   if (priv->texture)
-    glFramebufferTexture2D (GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT,
+    glFramebufferTexture2D (GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                             GL_TEXTURE_2D, priv->texture, 0);
   else if (priv->render_buffer)
-    glFramebufferRenderbufferEXT (GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT,
-                                  GL_RENDERBUFFER_EXT, priv->render_buffer);
+    glFramebufferRenderbuffer (GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                               GL_RENDERBUFFER, priv->render_buffer);
 
   if (priv->depth_stencil_buffer)
     {
       if (priv->has_depth_buffer)
-        glFramebufferRenderbufferEXT (GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT,
-                                      GL_RENDERBUFFER_EXT, priv->depth_stencil_buffer);
+        glFramebufferRenderbuffer (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                   GL_RENDERBUFFER, priv->depth_stencil_buffer);
       if (priv->has_stencil_buffer)
-        glFramebufferRenderbufferEXT (GL_FRAMEBUFFER_EXT, GL_STENCIL_ATTACHMENT_EXT,
-                                      GL_RENDERBUFFER_EXT, priv->depth_stencil_buffer);
+        glFramebufferRenderbuffer (GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+                                   GL_RENDERBUFFER, priv->depth_stencil_buffer);
     }
 }
 
@@ -546,7 +546,7 @@ gtk_gl_area_delete_buffers (GtkGLArea *area)
 
   if (priv->render_buffer != 0)
     {
-      glDeleteRenderbuffersEXT (1, &priv->render_buffer);
+      glDeleteRenderbuffers (1, &priv->render_buffer);
       priv->render_buffer = 0;
     }
 
@@ -558,14 +558,14 @@ gtk_gl_area_delete_buffers (GtkGLArea *area)
 
   if (priv->depth_stencil_buffer != 0)
     {
-      glDeleteRenderbuffersEXT (1, &priv->depth_stencil_buffer);
+      glDeleteRenderbuffers (1, &priv->depth_stencil_buffer);
       priv->depth_stencil_buffer = 0;
     }
 
   if (priv->frame_buffer != 0)
     {
-      glBindFramebufferEXT (GL_FRAMEBUFFER_EXT, 0);
-      glDeleteFramebuffersEXT (1, &priv->frame_buffer);
+      glBindFramebuffer (GL_FRAMEBUFFER, 0);
+      glDeleteFramebuffers (1, &priv->frame_buffer);
       priv->frame_buffer = 0;
     }
 }
@@ -697,6 +697,21 @@ gtk_gl_area_draw (GtkWidget *widget,
 
   gtk_gl_area_attach_buffers (area);
 
+  status = glCheckFramebufferStatus (GL_FRAMEBUFFER);
+  if (status != GL_FRAMEBUFFER_COMPLETE)
+    {
+      g_set_error_literal (&priv->error,
+                           GDK_GL_ERROR, GDK_GL_ERROR_UNSUPPORTED_FORMAT,
+                           "Unsupported framebuffer configuration");
+
+      gtk_gl_area_draw_error_screen (area,
+                                     cr,
+                                     gtk_widget_get_allocated_width (widget),
+                                     gtk_widget_get_allocated_height (widget));
+
+      return FALSE;
+    }
+
  if (priv->has_depth_buffer)
    glEnable (GL_DEPTH_TEST);
  else
@@ -706,33 +721,25 @@ gtk_gl_area_draw (GtkWidget *widget,
   w = gtk_widget_get_allocated_width (widget) * scale;
   h = gtk_widget_get_allocated_height (widget) * scale;
 
-  status = glCheckFramebufferStatusEXT (GL_FRAMEBUFFER_EXT);
-  if (status == GL_FRAMEBUFFER_COMPLETE_EXT)
+  if (priv->needs_render || priv->auto_render)
     {
-      if (priv->needs_render || priv->auto_render)
+      if (priv->needs_resize)
         {
-          if (priv->needs_resize)
-            {
-              g_signal_emit (area, area_signals[RESIZE], 0, w, h, NULL);
-              priv->needs_resize = FALSE;
-            }
-
-          g_signal_emit (area, area_signals[RENDER], 0, priv->context, &unused);
+          g_signal_emit (area, area_signals[RESIZE], 0, w, h, NULL);
+          priv->needs_resize = FALSE;
         }
 
-      priv->needs_render = FALSE;
+      g_signal_emit (area, area_signals[RENDER], 0, priv->context, &unused);
+    }
 
-      gdk_cairo_draw_from_gl (cr,
-                              gtk_widget_get_window (widget),
-                              priv->texture ? priv->texture : priv->render_buffer,
-                              priv->texture ? GL_TEXTURE : GL_RENDERBUFFER,
-                              scale, 0, 0, w, h);
-      gtk_gl_area_make_current (area);
-    }
-  else
-    {
-      g_warning ("fb setup not supported");
-    }
+  priv->needs_render = FALSE;
+
+  gdk_cairo_draw_from_gl (cr,
+                          gtk_widget_get_window (widget),
+                          priv->texture ? priv->texture : priv->render_buffer,
+                          priv->texture ? GL_TEXTURE : GL_RENDERBUFFER,
+                          scale, 0, 0, w, h);
+  gtk_gl_area_make_current (area);
 
   return TRUE;
 }

--- a/gtk/gtkicontheme.c
+++ b/gtk/gtkicontheme.c
@@ -1370,6 +1370,15 @@ load_themes (GtkIconTheme *icon_theme)
   if (priv->current_theme)
     insert_theme (icon_theme, priv->current_theme);
 
+  /* Make sure to always look in EndlessOS theme in case GTK+ can't find
+   * the actual theme currently selected via GSettings, which can happen
+   * for instance when in a ENOSPC situation (i.e. XSettings's property
+   * 'Net/IconThemeName' would not be set to the value set in the GSettings
+   * schema for org.gnome.desktop.interface.icon-theme from the xsettings
+   * plugin in gnome-settings-manager, due to broken connectino via dconf).
+   */
+  insert_theme (icon_theme, "EndlessOS");
+
   /* Always look in the Adwaita, gnome and hicolor icon themes.
    * Looking in hicolor is mandated by the spec, looking in Adwaita
    * and gnome is a pragmatic solution to prevent missing icons in

--- a/gtk/gtkmain.c
+++ b/gtk/gtkmain.c
@@ -2228,8 +2228,13 @@ gtk_grab_add (GtkWidget *widget)
 {
   GtkWindowGroup *group;
   GtkWidget *old_grab_widget;
+  GtkWidget *toplevel;
 
   g_return_if_fail (widget != NULL);
+
+  toplevel = gtk_widget_get_toplevel (widget);
+  if (toplevel && gdk_window_get_window_type (gtk_widget_get_window (toplevel)) == GDK_WINDOW_OFFSCREEN)
+    return;
 
   if (!gtk_widget_has_grab (widget) && gtk_widget_is_sensitive (widget))
     {

--- a/gtk/gtkmain.c
+++ b/gtk/gtkmain.c
@@ -2321,9 +2321,14 @@ gtk_device_grab_add (GtkWidget *widget,
 {
   GtkWindowGroup *group;
   GtkWidget *old_grab_widget;
+  GdkWindow *toplevel;
 
   g_return_if_fail (GTK_IS_WIDGET (widget));
   g_return_if_fail (GDK_IS_DEVICE (device));
+  
+  toplevel = gdk_window_get_toplevel (gtk_widget_get_window (widget));
+  if (toplevel && gdk_window_get_window_type (toplevel) == GDK_WINDOW_OFFSCREEN)
+    return;
 
   group = gtk_main_get_window_group (widget);
   old_grab_widget = gtk_window_group_get_current_device_grab (group, device);

--- a/gtk/gtkplacessidebar.c
+++ b/gtk/gtkplacessidebar.c
@@ -169,10 +169,6 @@ struct _GtkPlacesSidebar {
   GtkSidebarRow *context_row;
   GSList *shortcuts;
 
-  GDBusProxy *hostnamed_proxy;
-  GCancellable *hostnamed_cancellable;
-  gchar *hostname;
-
   GtkPlacesOpenFlags open_flags;
 
   GActionGroup *action_group;
@@ -1351,19 +1347,6 @@ update_places (GtkPlacesSidebar *sidebar)
       g_object_unref (volume);
     }
   g_list_free (volumes);
-
-  /* file system root */
-  if (!sidebar->show_other_locations)
-    {
-      mount_uri = "file:///"; /* No need to strdup */
-      start_icon = g_themed_icon_new_with_default_fallbacks (ICON_NAME_FILESYSTEM);
-      add_place (sidebar, PLACES_BUILT_IN,
-                 SECTION_MOUNTS,
-                 sidebar->hostname, start_icon, NULL, mount_uri,
-                 NULL, NULL, NULL, NULL, 0,
-                 _("Open the contents of the file system"));
-      g_object_unref (start_icon);
-    }
 
   /* add mounts that has no volume (/etc/mtab mounts, ftp, sftp,...) */
   mounts = g_volume_monitor_get_mounts (sidebar->volume_monitor);
@@ -3927,66 +3910,6 @@ list_box_sort_func (GtkListBoxRow *row1,
 }
 
 static void
-update_hostname (GtkPlacesSidebar *sidebar)
-{
-  GVariant *variant;
-  gsize len;
-  const gchar *hostname;
-
-  if (sidebar->hostnamed_proxy == NULL)
-    return;
-
-  variant = g_dbus_proxy_get_cached_property (sidebar->hostnamed_proxy,
-                                              "PrettyHostname");
-  if (variant == NULL)
-    return;
-
-  hostname = g_variant_get_string (variant, &len);
-  if (len > 0 &&
-      g_strcmp0 (sidebar->hostname, hostname) != 0)
-    {
-      g_free (sidebar->hostname);
-      sidebar->hostname = g_strdup (hostname);
-      update_places (sidebar);
-    }
-
-  g_variant_unref (variant);
-}
-
-static void
-hostname_proxy_new_cb (GObject      *source_object,
-                       GAsyncResult *res,
-                       gpointer      user_data)
-{
-  GtkPlacesSidebar *sidebar = user_data;
-  GError *error = NULL;
-  GDBusProxy *proxy;
-
-  proxy = g_dbus_proxy_new_for_bus_finish (res, &error);
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-    {
-      g_error_free (error);
-      return;
-    }
-
-  sidebar->hostnamed_proxy = proxy;
-  g_clear_object (&sidebar->hostnamed_cancellable);
-
-  if (error != NULL)
-    {
-      g_debug ("Failed to create D-Bus proxy: %s", error->message);
-      g_error_free (error);
-      return;
-    }
-
-  g_signal_connect_swapped (sidebar->hostnamed_proxy,
-                            "g-properties-changed",
-                            G_CALLBACK (update_hostname),
-                            sidebar);
-  update_hostname (sidebar);
-}
-
-static void
 create_volume_monitor (GtkPlacesSidebar *sidebar)
 {
   g_assert (sidebar->volume_monitor == NULL);
@@ -4123,18 +4046,6 @@ gtk_places_sidebar_init (GtkPlacesSidebar *sidebar)
   sidebar->drag_data_info = DND_UNKNOWN;
 
   gtk_container_add (GTK_CONTAINER (sidebar), sidebar->list_box);
-
-  sidebar->hostname = g_strdup (_("Computer"));
-  sidebar->hostnamed_cancellable = g_cancellable_new ();
-  g_dbus_proxy_new_for_bus (G_BUS_TYPE_SYSTEM,
-                            G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,
-                            NULL,
-                            "org.freedesktop.hostname1",
-                            "/org/freedesktop/hostname1",
-                            "org.freedesktop.hostname1",
-                            sidebar->hostnamed_cancellable,
-                            hostname_proxy_new_cb,
-                            sidebar);
 
   sidebar->drop_state = DROP_STATE_NORMAL;
 
@@ -4348,16 +4259,6 @@ gtk_places_sidebar_dispose (GObject *object)
                                             update_places, sidebar);
       g_clear_object (&sidebar->volume_monitor);
     }
-
-  if (sidebar->hostnamed_cancellable != NULL)
-    {
-      g_cancellable_cancel (sidebar->hostnamed_cancellable);
-      g_clear_object (&sidebar->hostnamed_cancellable);
-    }
-
-  g_clear_object (&sidebar->hostnamed_proxy);
-  g_free (sidebar->hostname);
-  sidebar->hostname = NULL;
 
   if (sidebar->gtk_settings)
     {

--- a/gtk/gtkwindow.c
+++ b/gtk/gtkwindow.c
@@ -12361,6 +12361,9 @@ ensure_state_flag_backdrop (GtkWidget *widget)
   GdkWindow *window;
   gboolean window_focused = TRUE;
 
+  if (g_strcmp0 (g_getenv ("GTK_BACKDROP_STYLING"), "0") == 0)
+    return;
+
   window = _gtk_widget_get_window (widget);
 
   window_focused = gdk_window_get_state (window) & GDK_WINDOW_STATE_FOCUSED;

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -93,3 +93,14 @@ button.titlebutton.chromium {
   color: #8c8c8c;
   -gtk-icon-shadow: none;
 }
+
+button.titlebutton.chromium:hover {
+  color: #dcdcdc;
+  background-image: none;
+  border: none;
+  box-shadow: none;
+}
+
+button.titlebutton.chromium:active {
+  color: #787878;
+}

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -80,3 +80,10 @@ headerbar.default-decoration {
                                     #1e1e1e);
   box-shadow: none;
 }
+
+.header-bar.chromium:backdrop {
+  color: #807d78;
+  background-image: linear-gradient(to bottom,
+                                    #282828,
+                                    #1e1e1e);
+}

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -75,7 +75,8 @@ headerbar.default-decoration {
 
 /* Set dark background for Chrome and Chromium > 59 top bar */
 .header-bar.chromium {
-  background-image: none;
-  background-color: #464646;
+  background-image: linear-gradient(to bottom,
+                                    #464646,
+                                    #1e1e1e);
   box-shadow: none;
 }

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -87,3 +87,9 @@ headerbar.default-decoration {
                                     #282828,
                                     #1e1e1e);
 }
+
+/* Fix color of buttons for Chrome top bar */
+button.titlebutton.chromium {
+  color: #8c8c8c;
+  -gtk-icon-shadow: none;
+}

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -72,3 +72,10 @@ headerbar.default-decoration {
   border-style: solid;
   border-color: transparentize(black, 0.15);
 }
+
+/* Set dark background for Chrome and Chromium > 59 top bar */
+.header-bar.chromium {
+  background-image: none;
+  background-color: #464646;
+  box-shadow: none;
+}

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -1,0 +1,74 @@
+headerbar.default-decoration {
+  color: #dfdbd2;
+  background-image: linear-gradient(to bottom,
+                                    #464646,
+                                    #1e1e1e);
+  box-shadow: inset 0 -1px #0a0a0a,
+              inset 0 -2px #292929,
+              inset 0 1px  #4d4d4d;
+  border: none;
+  min-height: 36px;
+
+  &:dir(rtl) {
+    padding: 0 16px 0 6px;
+  }
+
+  &:dir(ltr) {
+    padding: 0 6px 0 16px;
+  }
+
+  &.maximized {
+    box-shadow: inset 0 -1px #0a0a0a,
+                inset 0 -2px #292929;
+  }
+
+  &:backdrop {
+    color: #807d78;
+    background-image: linear-gradient(to bottom,
+                                      #282828,
+                                      #1e1e1e);
+    box-shadow: inset 0 -1px #0a0a0a,
+                inset 0 -2px #292929,
+                inset 0 1px  #303030;
+
+    &.maximized {
+      box-shadow: inset 0 -1px #0a0a0a,
+                  inset 0 -2px #292929;
+    }
+  }
+
+  button.titlebutton {
+      color: #8c8c8c;
+      background-image: none;
+      border: none;
+      border-image: none;
+      box-shadow: none;
+      background-color: transparent;
+      border-radius: 2px;
+
+      &:hover {
+        color: #dcdcdc;
+        background-image: linear-gradient(to bottom,
+                                          rgb(131, 131, 131) 2%,
+                                          rgb(108, 108, 108) 5%,
+                                          rgb(68, 68, 68))
+      }
+      &:active {
+        color: #787878;
+        background-image: linear-gradient(to bottom,
+                                          rgb(79, 79, 79) 2%,
+                                          rgb(71, 71, 71) 5%,
+                                          rgb(67, 67, 67))
+      }
+      &:backdrop {
+        background-image: none;
+      }
+  }
+}
+
+/* Shadow beneath the top bar */
+.mutter-topbar-shadow {
+  border-width: 2px;
+  border-style: solid;
+  border-color: transparentize(black, 0.15);
+}

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -88,7 +88,7 @@ headerbar.default-decoration {
                                     #1e1e1e);
 }
 
-/* Fix color of buttons for Chrome top bar */
+/* Fix color of window management buttons for Chrome top bar */
 button.titlebutton.chromium {
   color: #8c8c8c;
   -gtk-icon-shadow: none;
@@ -103,4 +103,23 @@ button.titlebutton.chromium:hover {
 
 button.titlebutton.chromium:active {
   color: #787878;
+}
+
+/* Fix color of user button for Chrome top bar */
+.header-bar.chromium button:not(.titlebutton) {
+  border: none;
+  box-shadow: none;
+  background-image: none;
+}
+
+.header-bar.chromium button:not(.titlebutton):hover {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(78, 78, 78, 0.8);
+}
+
+.header-bar.chromium button:not(.titlebutton):active {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.3);
 }

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -2009,3 +2009,43 @@ read if you used those and something break with a version upgrade you're on your
 @define-color wm_button_active_color_b shade(#33393b, 0.89);
 @define-color wm_button_active_color_c shade(#33393b, 0.9);
 @define-color content_view_bg #232729;
+headerbar.default-decoration {
+  color: #dfdbd2;
+  background-image: linear-gradient(to bottom, #464646, #1e1e1e);
+  box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #4d4d4d;
+  border: none;
+  min-height: 36px; }
+  headerbar.default-decoration:dir(rtl) {
+    padding: 0 16px 0 6px; }
+  headerbar.default-decoration:dir(ltr) {
+    padding: 0 6px 0 16px; }
+  headerbar.default-decoration.maximized {
+    box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+  headerbar.default-decoration:backdrop {
+    color: #807d78;
+    background-image: linear-gradient(to bottom, #282828, #1e1e1e);
+    box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #303030; }
+    headerbar.default-decoration:backdrop.maximized {
+      box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+  headerbar.default-decoration button.titlebutton {
+    color: #8c8c8c;
+    background-image: none;
+    border: none;
+    border-image: none;
+    box-shadow: none;
+    background-color: transparent;
+    border-radius: 2px; }
+    headerbar.default-decoration button.titlebutton:hover {
+      color: #dcdcdc;
+      background-image: linear-gradient(to bottom, #838383 2%, #6c6c6c 5%, #444444); }
+    headerbar.default-decoration button.titlebutton:active {
+      color: #787878;
+      background-image: linear-gradient(to bottom, #4f4f4f 2%, #474747 5%, #434343); }
+    headerbar.default-decoration button.titlebutton:backdrop {
+      background-image: none; }
+
+/* Shadow beneath the top bar */
+.mutter-topbar-shadow {
+  border-width: 2px;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.85); }

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -2049,3 +2049,9 @@ headerbar.default-decoration {
   border-width: 2px;
   border-style: solid;
   border-color: rgba(0, 0, 0, 0.85); }
+
+/* Set dark background for Chrome and Chromium > 59 top bar */
+.header-bar.chromium {
+  background-image: none;
+  background-color: #464646;
+  box-shadow: none; }

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -2052,6 +2052,23 @@ headerbar.default-decoration {
 
 /* Set dark background for Chrome and Chromium > 59 top bar */
 .header-bar.chromium {
-  background-image: none;
-  background-color: #464646;
+  background-image: linear-gradient(to bottom, #464646, #1e1e1e);
   box-shadow: none; }
+
+.header-bar.chromium:backdrop {
+  color: #807d78;
+  background-image: linear-gradient(to bottom, #282828, #1e1e1e); }
+
+/* Fix color of buttons for Chrome top bar */
+button.titlebutton.chromium {
+  color: #8c8c8c;
+  -gtk-icon-shadow: none; }
+
+button.titlebutton.chromium:hover {
+  color: #dcdcdc;
+  background-image: none;
+  border: none;
+  box-shadow: none; }
+
+button.titlebutton.chromium:active {
+  color: #787878; }

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -2059,7 +2059,7 @@ headerbar.default-decoration {
   color: #807d78;
   background-image: linear-gradient(to bottom, #282828, #1e1e1e); }
 
-/* Fix color of buttons for Chrome top bar */
+/* Fix color of window management buttons for Chrome top bar */
 button.titlebutton.chromium {
   color: #8c8c8c;
   -gtk-icon-shadow: none; }
@@ -2072,3 +2072,19 @@ button.titlebutton.chromium:hover {
 
 button.titlebutton.chromium:active {
   color: #787878; }
+
+/* Fix color of user button for Chrome top bar */
+.header-bar.chromium button:not(.titlebutton) {
+  border: none;
+  box-shadow: none;
+  background-image: none; }
+
+.header-bar.chromium button:not(.titlebutton):hover {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(78, 78, 78, 0.8); }
+
+.header-bar.chromium button:not(.titlebutton):active {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.3); }

--- a/gtk/theme/Adwaita/gtk-contained-dark.scss
+++ b/gtk/theme/Adwaita/gtk-contained-dark.scss
@@ -4,3 +4,4 @@ $variant: 'dark';
 @import 'drawing';
 @import 'common';
 @import 'colors-public';
+@import 'endless';

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -2029,3 +2029,43 @@ read if you used those and something break with a version upgrade you're on your
 @define-color wm_button_active_color_b shade(#e8e8e7, 0.89);
 @define-color wm_button_active_color_c shade(#e8e8e7, 0.9);
 @define-color content_view_bg #ffffff;
+headerbar.default-decoration {
+  color: #dfdbd2;
+  background-image: linear-gradient(to bottom, #464646, #1e1e1e);
+  box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #4d4d4d;
+  border: none;
+  min-height: 36px; }
+  headerbar.default-decoration:dir(rtl) {
+    padding: 0 16px 0 6px; }
+  headerbar.default-decoration:dir(ltr) {
+    padding: 0 6px 0 16px; }
+  headerbar.default-decoration.maximized {
+    box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+  headerbar.default-decoration:backdrop {
+    color: #807d78;
+    background-image: linear-gradient(to bottom, #282828, #1e1e1e);
+    box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #303030; }
+    headerbar.default-decoration:backdrop.maximized {
+      box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+  headerbar.default-decoration button.titlebutton {
+    color: #8c8c8c;
+    background-image: none;
+    border: none;
+    border-image: none;
+    box-shadow: none;
+    background-color: transparent;
+    border-radius: 2px; }
+    headerbar.default-decoration button.titlebutton:hover {
+      color: #dcdcdc;
+      background-image: linear-gradient(to bottom, #838383 2%, #6c6c6c 5%, #444444); }
+    headerbar.default-decoration button.titlebutton:active {
+      color: #787878;
+      background-image: linear-gradient(to bottom, #4f4f4f 2%, #474747 5%, #434343); }
+    headerbar.default-decoration button.titlebutton:backdrop {
+      background-image: none; }
+
+/* Shadow beneath the top bar */
+.mutter-topbar-shadow {
+  border-width: 2px;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.85); }

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -2079,7 +2079,7 @@ headerbar.default-decoration {
   color: #807d78;
   background-image: linear-gradient(to bottom, #282828, #1e1e1e); }
 
-/* Fix color of buttons for Chrome top bar */
+/* Fix color of window management buttons for Chrome top bar */
 button.titlebutton.chromium {
   color: #8c8c8c;
   -gtk-icon-shadow: none; }
@@ -2092,3 +2092,19 @@ button.titlebutton.chromium:hover {
 
 button.titlebutton.chromium:active {
   color: #787878; }
+
+/* Fix color of user button for Chrome top bar */
+.header-bar.chromium button:not(.titlebutton) {
+  border: none;
+  box-shadow: none;
+  background-image: none; }
+
+.header-bar.chromium button:not(.titlebutton):hover {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(78, 78, 78, 0.8); }
+
+.header-bar.chromium button:not(.titlebutton):active {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.3); }

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -2069,3 +2069,9 @@ headerbar.default-decoration {
   border-width: 2px;
   border-style: solid;
   border-color: rgba(0, 0, 0, 0.85); }
+
+/* Set dark background for Chrome and Chromium > 59 top bar */
+.header-bar.chromium {
+  background-image: none;
+  background-color: #464646;
+  box-shadow: none; }

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -2072,6 +2072,23 @@ headerbar.default-decoration {
 
 /* Set dark background for Chrome and Chromium > 59 top bar */
 .header-bar.chromium {
-  background-image: none;
-  background-color: #464646;
+  background-image: linear-gradient(to bottom, #464646, #1e1e1e);
   box-shadow: none; }
+
+.header-bar.chromium:backdrop {
+  color: #807d78;
+  background-image: linear-gradient(to bottom, #282828, #1e1e1e); }
+
+/* Fix color of buttons for Chrome top bar */
+button.titlebutton.chromium {
+  color: #8c8c8c;
+  -gtk-icon-shadow: none; }
+
+button.titlebutton.chromium:hover {
+  color: #dcdcdc;
+  background-image: none;
+  border: none;
+  box-shadow: none; }
+
+button.titlebutton.chromium:active {
+  color: #787878; }

--- a/gtk/theme/Adwaita/gtk-contained.scss
+++ b/gtk/theme/Adwaita/gtk-contained.scss
@@ -10,3 +10,4 @@ $variant: 'light';
 @import 'drawing';
 @import 'common';
 @import 'colors-public';
+@import 'endless';

--- a/gtk/ui/gtkfilechooserwidget.ui
+++ b/gtk/ui/gtkfilechooserwidget.ui
@@ -12,17 +12,22 @@
           <object class="GtkPaned" id="browse_widgets_hpaned">
             <property name="visible">1</property>
             <child>
-              <object class="GtkPlacesSidebar" id="places_sidebar">
+              <object class="GtkBox" id="places_sidebar_box">
                 <property name="visible">1</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="local-only">1</property>
-                <property name="show-other-locations">1</property>
-                <style>
-                  <class name="sidebar"/>
-                </style>
-                <signal name="open-location" handler="places_sidebar_open_location_cb" swapped="no"/>
-                <signal name="show-error-message" handler="places_sidebar_show_error_message_cb" swapped="no"/>
-                <signal name="show-other-locations-with-flags" handler="places_sidebar_show_other_locations_with_flags_cb" swapped="no"/>
+                <child>
+                  <object class="GtkPlacesSidebar" id="places_sidebar">
+                    <property name="visible">1</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="local-only">1</property>
+                    <property name="show-other-locations">1</property>
+                    <style>
+                      <class name="sidebar"/>
+                    </style>
+                    <signal name="open-location" handler="places_sidebar_open_location_cb" swapped="no"/>
+                    <signal name="show-error-message" handler="places_sidebar_show_error_message_cb" swapped="no"/>
+                    <signal name="show-other-locations-with-flags" handler="places_sidebar_show_other_locations_with_flags_cb" swapped="no"/>
+                  </object>
+                </child>
               </object>
               <packing>
                 <property name="resize">0</property>
@@ -34,110 +39,141 @@
                 <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkRevealer" id="browse_header_revealer">
+                  <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="hexpand">1</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="name">pathbarbox</property>
+                    <style>
+                      <class name="view"/>
+                    </style>
                     <child>
-                      <object class="GtkBox">
-                        <property name="visible">1</property>
-                        <property name="name">pathbarbox</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">12</property>
-                        <style>
-                          <class name="view"/>
-                        </style>
+                      <object class="GtkMenuButton" id="browse_places_button">
+                        <property name="tooltip-text" translatable="yes">Show other locations</property>
+                        <property name="use-underline">1</property>
+                        <property name="valign">center</property>
+                        <property name="halign">center</property>
+                        <property name="border_width">6</property>
+                        <property name="sensitive">1</property>
+                        <property name="active">1</property>
                         <child>
-                          <object class="GtkStack" id="browse_header_stack">
+                          <object class="GtkImage">
                             <property name="visible">1</property>
-                            <property name="transition-type">crossfade</property>
+                            <property name="icon-name">folder-symbolic</property>
+                            <property name="icon-size">1</property>
+                          </object>
+                        </child>
+                        <signal name="toggled" handler="browse_places_button_changed_cb" swapped="yes"/>
+                      </object>
+                      <packing>
+                        <property name="fill">0</property>
+                        <property name="pack-type">start</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRevealer" id="browse_header_revealer">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="GtkBox">
+                              <object class="GtkStack" id="browse_header_stack">
                                 <property name="visible">1</property>
-                                <property name="spacing">6</property>
-                                <property name="border-width">6</property>
+                                <property name="transition-type">crossfade</property>
                                 <child>
-                                  <object class="GtkPathBar" id="browse_path_bar">
-                                    <property name="visible">True</property>
-                                    <signal name="path-clicked" handler="path_bar_clicked" after="yes" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkMenuButton" id="browse_new_folder_button">
-                                    <property name="tooltip-text" translatable="yes">Create Folder</property>
-                                    <property name="use-underline">1</property>
-                                    <property name="popover">new_folder_popover</property>
-                                    <signal name="notify::active" handler="new_folder_popover_active"/>
+                                  <object class="GtkBox">
+                                    <property name="visible">1</property>
+                                    <property name="spacing">6</property>
+                                    <property name="border-width">6</property>
                                     <child>
-                                      <object class="GtkImage">
-                                        <property name="visible">1</property>
-                                        <property name="icon-name">folder-new-symbolic</property>
-                                        <property name="icon-size">1</property>
+                                      <object class="GtkPathBar" id="browse_path_bar">
+                                        <property name="visible">True</property>
+                                        <signal name="path-clicked" handler="path_bar_clicked" after="yes" swapped="no"/>
                                       </object>
+                                      <packing>
+                                        <property name="expand">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkMenuButton" id="browse_new_folder_button">
+                                        <property name="tooltip-text" translatable="yes">Create Folder</property>
+                                        <property name="use-underline">1</property>
+                                        <property name="popover">new_folder_popover</property>
+                                        <signal name="notify::active" handler="new_folder_popover_active"/>
+                                        <child>
+                                          <object class="GtkImage">
+                                            <property name="visible">1</property>
+                                            <property name="icon-name">folder-new-symbolic</property>
+                                            <property name="icon-size">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="fill">0</property>
+                                        <property name="pack-type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="fill">0</property>
-                                    <property name="pack-type">end</property>
-                                    <property name="position">1</property>
+                                    <property name="name">pathbar</property>
                                   </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="name">pathbar</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="location_entry_box">
-                                <property name="visible">1</property>
-                                <property name="no-show-all">1</property>
-                                <property name="spacing">6</property>
-                                <property name="border-width">6</property>
-                              </object>
-                              <packing>
-                                <property name="name">location</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="search_entry_box">
-                                <property name="visible">1</property>
-                                <property name="no-show-all">1</property>
-                                <property name="spacing">6</property>
-                                <property name="border-width">6</property>
-                                <child type="center">
-                                  <object class="GtkSearchEntry" id="search_entry">
-                                    <property name="visible">1</property>
-                                    <property name="width-chars">45</property>
-                                    <signal name="search-changed" handler="search_entry_activate_cb" swapped="yes"/>
-                                    <signal name="stop-search" handler="search_entry_stop_cb" swapped="yes"/>
-                                  </object>
                                 </child>
                                 <child>
-                                  <object class="GtkSpinner" id="search_spinner">
-                                    <property name="active">1</property>
+                                  <object class="GtkBox" id="location_entry_box">
+                                    <property name="visible">1</property>
+                                    <property name="no-show-all">1</property>
+                                    <property name="spacing">6</property>
+                                    <property name="border-width">6</property>
                                   </object>
                                   <packing>
-                                    <property name="pack-type">end</property>
+                                    <property name="name">location</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="search_entry_box">
+                                    <property name="visible">1</property>
+                                    <property name="no-show-all">1</property>
+                                    <property name="spacing">6</property>
+                                    <property name="border-width">6</property>
+                                    <child type="center">
+                                      <object class="GtkSearchEntry" id="search_entry">
+                                        <property name="visible">1</property>
+                                        <property name="width-chars">45</property>
+                                        <signal name="search-changed" handler="search_entry_activate_cb" swapped="yes"/>
+                                        <signal name="stop-search" handler="search_entry_stop_cb" swapped="yes"/>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinner" id="search_spinner">
+                                        <property name="active">1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="pack-type">end</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="name">search</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="name">search</property>
+                                <property name="fill">0</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="fill">0</property>
-                          </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="fill">1</property>
+                        <property name="expand">1</property>
+                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="fill">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="list_and_preview_box">
@@ -359,7 +395,8 @@
                 </child>
               </object>
               <packing>
-                <property name="shrink">0</property>
+                <property name="shrink">1</property>
+                <property name="resize">1</property>
               </packing>
             </child>
           </object>

--- a/gtk/ui/gtkfilechooserwidget.ui
+++ b/gtk/ui/gtkfilechooserwidget.ui
@@ -411,37 +411,51 @@
       </packing>
     </child>
     <child>
-      <object class="GtkActionBar" id="extra_and_filters">
-        <property name="no-show-all">1</property>
+      <object class="GtkScrolledWindow" id="extra_and_filters_scroll">
+        <property name="visible">1</property>
+        <property name="vscrollbar-policy">never</property>
+        <property name="hscrollbar-policy">never</property>
         <child>
-          <object class="GtkBox" id="extra_align">
+          <object class="GtkViewport">
             <property name="visible">1</property>
-            <property name="spacing">12</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox" id="filter_combo_hbox">
-            <property name="visible">1</property>
-            <property name="spacing">12</property>
+            <property name="shadow-type">none</property>
             <child>
-              <object class="GtkComboBoxText" id="filter_combo">
-                <property name="visible">1</property>
-                <property name="tooltip-text" translatable="yes">Select which types of files are shown</property>
-                <property name="focus-on-click">0</property>
-                <property name="entry-text-column">0</property>
-                <property name="id-column">1</property>
+              <object class="GtkActionBar" id="extra_and_filters">
+                <property name="no-show-all">1</property>
                 <property name="valign">start</property>
-                <signal name="changed" handler="filter_combo_changed" swapped="no"/>
+                <child>
+                  <object class="GtkBox" id="extra_align">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="filter_combo_hbox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkComboBoxText" id="filter_combo">
+                        <property name="visible">1</property>
+                        <property name="tooltip-text" translatable="yes">Select which types of files are shown</property>
+                        <property name="focus-on-click">0</property>
+                        <property name="entry-text-column">0</property>
+                        <property name="id-column">1</property>
+                        <signal name="changed" handler="filter_combo_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="fill">0</property>
+                        <property name="pack-type">end</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="pack-type">end</property>
+                  </packing>
+                </child>
+                <signal name="size-allocate" handler="extra_and_filters_size_allocate_cb" swapped="yes"/>
               </object>
-              <packing>
-                <property name="fill">0</property>
-                <property name="pack-type">end</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="pack-type">end</property>
-          </packing>
         </child>
       </object>
       <packing>

--- a/gtk/updateiconcache.c
+++ b/gtk/updateiconcache.c
@@ -676,7 +676,7 @@ scan_directory (const gchar *base_path,
 		      directories = g_list_append (directories, g_strdup (subdir));
 		    }
 		  else
-		    dir_index = 0xffff;
+		    continue;
 		}
 
 	      image = g_new0 (Image, 1);

--- a/modules/input/Makefile.am
+++ b/modules/input/Makefile.am
@@ -191,7 +191,7 @@ WAYLAND_MODULE = im-wayland.la
 endif
 endif
 
-multipress_defs = -DMULTIPRESS_LOCALEDIR=\""$(mplocaledir)"\" -DMULTIPRESS_CONFDIR=\""$(sysconfdir)/gtk-2.0"\"
+multipress_defs = -DMULTIPRESS_LOCALEDIR=\""$(mplocaledir)"\" -DMULTIPRESS_CONFDIR=\""$(sysconfdir)/gtk-3.0"\"
 im_multipress_la_CPPFLAGS = $(AM_CPPFLAGS) $(multipress_defs)
 libstatic_im_multipress_la_CPPFLAGS = $(im_multipress_la_CPPFLAGS)
 im_multipress_la_LDFLAGS = -rpath $(moduledir) -avoid-version -module $(no_undefined)

--- a/modules/input/imviqr.c
+++ b/modules/input/imviqr.c
@@ -242,7 +242,7 @@ static const GtkIMContextInfo viqr_info = {
   NC_("input method menu", "Vietnamese (VIQR)"), /* Human readable name */
   GETTEXT_PACKAGE,	   /* Translation domain */
    GTK_LOCALEDIR,	   /* Dir for bindtextdomain (not strictly needed for "gtk+") */
-  "vi"			   /* Languages for which this module is the default */
+  ""			   /* Languages for which this module is the default */
 };
 
 static const GtkIMContextInfo *info_list[] = {

--- a/modules/printbackends/papi/Makefile.am
+++ b/modules/printbackends/papi/Makefile.am
@@ -14,7 +14,7 @@ LDADDS = \
 	$(top_builddir)/gtk/libgtk-3.la	\
 	$(GTK_DEP_LIBS)
 
-backenddir = $(libdir)/gtk-2.0/$(GTK_BINARY_VERSION)/printbackends
+backenddir = $(libdir)/gtk-3.0/$(GTK_BINARY_VERSION)/printbackends
 
 backend_LTLIBRARIES = libprintbackend-papi.la
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,8 @@
 ## Makefile.am for gtk+/tests
 include $(top_srcdir)/Makefile.decl
 
+CLEANFILES =
+
 SUBDIRS = visuals
 
 AM_CPPFLAGS =				\
@@ -307,6 +309,13 @@ testtitlebar_DEPENDENCIES = $(TEST_DEPS)
 testwindowsize_DEPENDENCIES = $(TEST_DEPS)
 listmodel_DEPENDENCIES = $(TEST_DEPS)
 
+# Add the blur files in BUILT_SOURCES instead of in blur_performance_SOURCES
+# directly because we want them to be generated before build time.
+BUILT_SOURCES = \
+	gtkcairoblurprivate.h 	\
+	gtkcairoblur.c
+
+
 animated_resizing_SOURCES = 	\
 	animated-resizing.c	\
 	frame-stats.c		\
@@ -330,7 +339,7 @@ scrolling_performance_SOURCES = \
 
 blur_performance_SOURCES = \
 	blur-performance.c	\
-	../gtk/gtkcairoblur.c
+	$(BUILT_SOURCES)
 
 video_timer_SOURCES = 	\
 	video-timer.c	\
@@ -573,5 +582,13 @@ EXTRA_DIST += 			\
 	mydialog2.ui		\
 	popover.ui		\
 	selectionmode.ui
+
+gtkcairoblurprivate.h: $(top_srcdir)/gtk/gtkcairoblurprivate.h
+	$(AM_V_GEN) $(LN_S) $^ $@
+
+gtkcairoblur.c: $(top_srcdir)/gtk/gtkcairoblur.c
+	$(AM_V_GEN) $(LN_S) $^ $@
+
+CLEANFILES += gtkcairoblurprivate.h gtkcairoblur.c
 
 -include $(top_srcdir)/git.mk

--- a/testsuite/a11y/Makefile.am
+++ b/testsuite/a11y/Makefile.am
@@ -28,7 +28,7 @@ TESTS_ENVIRONMENT = 			\
 	GTK_CSD=1			\
 	G_ENABLE_DIAGNOSTIC=0
 
-TEST_PROGS += accessibility-dump
+#TEST_PROGS += accessibility-dump
 
 TEST_PROGS += tree-performance
 

--- a/testsuite/gtk/treeview.c
+++ b/testsuite/gtk/treeview.c
@@ -355,8 +355,10 @@ main (int    argc,
   g_test_add_func ("/TreeView/cursor/bug-539377", test_bug_539377);
   g_test_add_func ("/TreeView/cursor/select-collapsed_row",
                    test_select_collapsed_row);
+  /* See http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=711107
+   * and https://bugzilla.gnome.org/show_bug.cgi?id=702371
   g_test_add_func ("/TreeView/sizing/row-separator-height",
-                   test_row_separator_height);
+                   test_row_separator_height);*/
   g_test_add_func ("/TreeView/selection/count", test_selection_count);
   g_test_add_func ("/TreeView/selection/empty", test_selection_empty);
 

--- a/testsuite/reftests/Makefile.am
+++ b/testsuite/reftests/Makefile.am
@@ -63,6 +63,15 @@ gtk_reftest_SOURCES = \
 	gtk-reftest.c			\
 	gtk-reftest.h
 
+EXTRA_DIST += \
+	window-show-contents-on-map.ui.known_fail \
+	inherit-and-initial.ui.known_fail \
+	textview-margins.ui.known_fail \
+	box-shadow-changes-modify-clip.ui.known_fail \
+	label-sizing.ui.known_fail \
+	label-text-shadow-changes-modify-clip.ui.known_fail \
+	$(NULL)
+
 clean-local:
 	rm -rf output/ || true
 

--- a/testsuite/reftests/gtk-reftest.c
+++ b/testsuite/reftests/gtk-reftest.c
@@ -253,6 +253,20 @@ save_image (cairo_surface_t *surface,
   g_free (filename);
 }
 
+static gboolean
+known_fail(const char *test_name)
+{
+  char *filename = get_test_file (test_name, ".ui.known_fail", TRUE);
+
+  if (filename)
+    {
+      g_free (filename);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
 static void
 test_ui_file (GFile *file)
 {
@@ -285,7 +299,13 @@ test_ui_file (GFile *file)
   if (diff_image)
     {
       save_image (diff_image, ui_file, ".diff.png");
-      g_test_fail ();
+      if (known_fail(ui_file))
+        {
+          printf("KNOWN FAIL: ");
+          g_test_message ("KNOWN FAIL: %s", ui_file);
+        }
+      else
+        g_test_fail ();
     }
 
   remove_extra_css (provider);


### PR DESCRIPTION
Having the wrong directory for the multipress defs caused quickly typed
input characters to arrive out of order on the desktop search dialog
after removing gtk-2.0.
The printbackends might be intentional, as I don't 
This also appears to have impacted the build of the papi print backend.

https://phabricator.endlessm.com/T22887