### PR TITLE
debian/libgtk-3-0.symbols: Add new symbols from newly added API

### DIFF
--- a/debian/libgtk-3-0.symbols
+++ b/debian/libgtk-3-0.symbols
@@ -133,6 +133,7 @@ libgdk-3.so.0 libgtk-3-0 #MINVER#
  gdk_display_get_pointer@Base 3.0.0
  gdk_display_get_primary_monitor@Base 3.21.4
  gdk_display_get_screen@Base 3.0.0
+ gdk_display_get_startup_notification_id@Base 3.22.29
  gdk_display_get_type@Base 3.0.0
  gdk_display_get_window_at_pointer@Base 3.0.0
  gdk_display_has_pending@Base 3.0.0
@@ -492,6 +493,7 @@ libgdk-3.so.0 libgtk-3-0 #MINVER#
  (arch=linux-any)gdk_wayland_display_set_cursor_theme@Base 3.9.10
  (arch=linux-any)gdk_wayland_display_set_startup_notification_id@Base 3.22.4
  (arch=linux-any)gdk_wayland_gl_context_get_type@Base 3.16.2
+ (arch=linux-any)gdk_wayland_display_get_startup_notification_id@Base 3.22.29
  (arch=linux-any)gdk_wayland_monitor_get_type@Base 3.21.4
  (arch=linux-any)gdk_wayland_monitor_get_wl_output@Base 3.21.4
  (arch=linux-any)gdk_wayland_seat_get_wl_seat@Base 3.19.12


### PR DESCRIPTION
New symbols:
  - gdk_display_get_startup_notification_id
  - gdk_wayland_display_get_startup_notification_id

https://phabricator.endlessm.com/T22416