### PR TITLE
Revert "display: Avoid unsetting the DESKTOP_STARTUP_ID variable too …

### DIFF
--- a/gdk/gdk-private.c
+++ b/gdk/gdk-private.c
@@ -19,8 +19,6 @@ gdk__private__ (void)
     gdk_display_set_debug_updates,
     gdk_get_desktop_startup_id,
     gdk_get_desktop_autostart_id,
-    gdk_window_move_to_rect,
-    gdk_get_startup_notification_id
   };
 
   return &table;

--- a/gdk/gdk-private.h
+++ b/gdk/gdk-private.h
@@ -34,9 +34,6 @@ void             gdk_display_set_debug_updates (GdkDisplay *display,
 const gchar *   gdk_get_desktop_startup_id   (void);
 const gchar *   gdk_get_desktop_autostart_id (void);
 
-const gchar *   gdk_get_startup_notification_id (void);
-
-
 typedef struct {
   /* add all private functions here, initialize them in gdk-private.c */
   gboolean (* gdk_device_grab_info) (GdkDisplay  *display,
@@ -65,16 +62,6 @@ typedef struct {
 
   const gchar * (* gdk_get_desktop_startup_id)   (void);
   const gchar * (* gdk_get_desktop_autostart_id) (void);
-
-  void (* gdk_window_move_to_rect) (GdkWindow          *window,
-                                    const GdkRectangle *rect,
-                                    GdkGravity          rect_anchor,
-                                    GdkGravity          window_anchor,
-                                    GdkAnchorHints      anchor_hints,
-                                    gint                rect_anchor_dx,
-                                    gint                rect_anchor_dy);
-
-  const gchar * (* gdk_get_startup_notification_id) (void);
 } GdkPrivateVTable;
 
 GDK_AVAILABLE_IN_ALL

--- a/gdk/gdk.c
+++ b/gdk/gdk.c
@@ -213,35 +213,6 @@ gdk_arg_no_debug_cb (const char *key, const char *value, gpointer user_data, GEr
 }
 #endif /* G_ENABLE_DEBUG */
 
-#ifdef G_HAS_CONSTRUCTORS
-#ifdef G_DEFINE_CONSTRUCTOR_NEEDS_PRAGMA
-#pragma G_DEFINE_CONSTRUCTOR_PRAGMA_ARGS(stash_desktop_startup_notification_id)
-#endif
-G_DEFINE_CONSTRUCTOR(stash_desktop_startup_notification_id)
-#endif
-
-static gchar *startup_notification_id = NULL;
-
-static void
-stash_desktop_startup_notification_id (void)
-{
-  const char *desktop_startup_id;
-
-  desktop_startup_id = g_getenv ("DESKTOP_STARTUP_ID");
-  if (desktop_startup_id && *desktop_startup_id != '\0')
-    {
-      if (!g_utf8_validate (desktop_startup_id, -1, NULL))
-        g_warning ("DESKTOP_STARTUP_ID contains invalid UTF-8");
-      else
-        startup_notification_id = g_strdup (desktop_startup_id ? desktop_startup_id : "");
-    }
-
-  /* Clear the environment variable so it won't be inherited by
-   * child processes and confuse things.
-   */
-  g_unsetenv ("DESKTOP_STARTUP_ID");
-}
-
 static gboolean
 gdk_arg_class_cb (const char *key, const char *value, gpointer user_data, GError **error)
 {
@@ -370,10 +341,6 @@ gdk_pre_parse (void)
       else if (g_str_equal (rendering_mode, "recording"))
         _gdk_rendering_mode = GDK_RENDERING_MODE_RECORDING;
     }
-
-#ifndef G_HAS_CONSTRUCTORS
-  stash_desktop_startup_notification_id ();
-#endif
 }
 
 /**
@@ -436,22 +403,6 @@ gdk_parse_args (int    *argc,
   g_option_context_free (option_context);
 
   GDK_NOTE (MISC, g_message ("progname: \"%s\"", g_get_prgname ()));
-}
-
-/*< private >
- *
- * gdk_get_startup_notification_id
- *
- * Returns the original value of the DESKTOP_STARTUP_ID environment
- * variable if it was defined and valid, or %NULL otherwise.
- *
- * Returns: (nullable) (transfer none): the original value of the
- *   DESKTOP_STARTUP_ID environment variable, or %NULL.
- */
-const gchar *
-gdk_get_startup_notification_id (void)
-{
-  return startup_notification_id;
 }
 
 /**

--- a/gdk/wayland/gdkdisplay-wayland.c
+++ b/gdk/wayland/gdkdisplay-wayland.c
@@ -49,8 +49,6 @@
 #include "xdg-foreign-unstable-v1-client-protocol.h"
 #include "server-decoration-client-protocol.h"
 
-#include "gdk/gdk-private.h"
-
 /**
  * SECTION:wayland_interaction
  * @Short_description: Wayland backend-specific functions


### PR DESCRIPTION
…late"

This reverts commit e48a68ebd99e12ddfaf732ceab14d384bd41d16e. This commit
should have been dropped during the rebase, for GTK already stashes not
only DESKTOP_STARTUP_ID, but also DESKTOP_AUTOSTART_ID.

https://phabricator.endlessm.com/T26897