### PR TITLE
Remove shadows from titlebar buttons and legacy chromium user styles

### DIFF
--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -45,6 +45,7 @@ headerbar.default-decoration {
       box-shadow: none;
       background-color: transparent;
       border-radius: 2px;
+      -gtk-icon-shadow: none;
 
       &:hover {
         color: #dcdcdc;

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -99,22 +99,3 @@ button.titlebutton.chromium:hover {
 button.titlebutton.chromium:active {
   color: #787878;
 }
-
-/* Fix color of user button for Chrome top bar */
-.header-bar.chromium button:not(.titlebutton) {
-  border: none;
-  box-shadow: none;
-  background-image: none;
-}
-
-.header-bar.chromium button:not(.titlebutton):hover {
-  border: none;
-  box-shadow: none;
-  background-color: rgba(78, 78, 78, 0.8);
-}
-
-.header-bar.chromium button:not(.titlebutton):active {
-  border: none;
-  box-shadow: none;
-  background-color: rgba(0, 0, 0, 0.3);
-}

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -2093,10 +2093,3 @@ button.titlebutton.chromium { color: #8c8c8c; -gtk-icon-shadow: none; }
 button.titlebutton.chromium:hover { color: #dcdcdc; background-image: none; border: none; box-shadow: none; }
 
 button.titlebutton.chromium:active { color: #787878; }
-
-/* Fix color of user button for Chrome top bar */
-.header-bar.chromium button:not(.titlebutton) { border: none; box-shadow: none; background-image: none; }
-
-.header-bar.chromium button:not(.titlebutton):hover { border: none; box-shadow: none; background-color: rgba(78, 78, 78, 0.8); }
-
-.header-bar.chromium button:not(.titlebutton):active { border: none; box-shadow: none; background-color: rgba(0, 0, 0, 0.3); }

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -2074,7 +2074,7 @@ headerbar.default-decoration:backdrop { color: #807d78; background-image: linear
 
 headerbar.default-decoration:backdrop.maximized { box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
 
-headerbar.default-decoration button.titlebutton { color: #8c8c8c; background-image: none; border: none; border-image: none; box-shadow: none; background-color: transparent; border-radius: 2px; }
+headerbar.default-decoration button.titlebutton { color: #8c8c8c; background-image: none; border: none; border-image: none; box-shadow: none; background-color: transparent; border-radius: 2px; -gtk-icon-shadow: none; }
 
 headerbar.default-decoration button.titlebutton:hover { color: #dcdcdc; background-image: linear-gradient(to bottom, #838383 2%, #6c6c6c 5%, #444444); }
 

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -2109,10 +2109,3 @@ button.titlebutton.chromium { color: #8c8c8c; -gtk-icon-shadow: none; }
 button.titlebutton.chromium:hover { color: #dcdcdc; background-image: none; border: none; box-shadow: none; }
 
 button.titlebutton.chromium:active { color: #787878; }
-
-/* Fix color of user button for Chrome top bar */
-.header-bar.chromium button:not(.titlebutton) { border: none; box-shadow: none; background-image: none; }
-
-.header-bar.chromium button:not(.titlebutton):hover { border: none; box-shadow: none; background-color: rgba(78, 78, 78, 0.8); }
-
-.header-bar.chromium button:not(.titlebutton):active { border: none; box-shadow: none; background-color: rgba(0, 0, 0, 0.3); }

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -2090,7 +2090,7 @@ headerbar.default-decoration:backdrop { color: #807d78; background-image: linear
 
 headerbar.default-decoration:backdrop.maximized { box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
 
-headerbar.default-decoration button.titlebutton { color: #8c8c8c; background-image: none; border: none; border-image: none; box-shadow: none; background-color: transparent; border-radius: 2px; }
+headerbar.default-decoration button.titlebutton { color: #8c8c8c; background-image: none; border: none; border-image: none; box-shadow: none; background-color: transparent; border-radius: 2px; -gtk-icon-shadow: none; }
 
 headerbar.default-decoration button.titlebutton:hover { color: #dcdcdc; background-image: linear-gradient(to bottom, #838383 2%, #6c6c6c 5%, #444444); }
 


### PR DESCRIPTION
Make more generic the change that was removing the shadows from the titlebar buttons, and also remove some style overrides for the user information that chromium is now showing outside of the toolbar.