### PR TITLE
gdkglcontext-x11-eglx: Set current EGL context to null when destroyed

### DIFF
--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -661,7 +661,8 @@ gdk_x11_gl_context_dispose (GObject *gobject)
       GdkGLContext *context = GDK_GL_CONTEXT (gobject);
       GdkDisplay *display = gdk_gl_context_get_display (context);
 
-      if (eglGetCurrentContext () != context_x11->egl_context)
+      /* Unset the current context if we're disposing it */
+      if (eglGetCurrentContext () == context_x11->egl_context)
         eglMakeCurrent (gdk_x11_display_get_egl_display (display),
                         EGL_NO_SURFACE,
                         EGL_NO_SURFACE,


### PR DESCRIPTION
Previously, the current EGL context would be set to null when destroying
a GdkGLContext that is not the current context. That is different from
other backends and appears to be a mistake.

https://phabricator.endlessm.com/T26542