### PR TITLE
GTK 3.24.11 rebase

### DIFF
--- a/build/win32/Makefile.am
+++ b/build/win32/Makefile.am
@@ -28,12 +28,12 @@ endif
 
 SUBDIRS =	\
 	vs9 	\
-	vs10	\
-	vs11	\
-	vs12	\
-	vs14	\
-	vs15	\
-	vs16
+	vs10
+#	vs11	\
+#	vs12	\
+#	vs14	\
+#	vs15	\
+#	vs16
 
 EXTRA_DIST +=	\
 	config-msvc.mak		\

--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,10 @@ AC_ARG_ENABLE(xdamage,
               [AS_HELP_STRING([--enable-xdamage],
                               [support X Damage extension [default=maybe]])],,
               [enable_xdamage="maybe"])
+AC_ARG_ENABLE(egl-x11,
+              [AS_HELP_STRING([--enable-egl-x11],
+                              [Use EGL and XLib instead of GLX [default=no]])],,
+              [enable_egl_x11=no])
 
 AC_ARG_ENABLE(x11-backend,
               [AS_HELP_STRING([--enable-x11-backend],
@@ -1242,6 +1246,20 @@ if test "x$enable_x11_backend" = xyes; then
       AC_MSG_ERROR([Xdamage support requested but xdamage not found])
     fi
   fi
+
+  # Checks whether to use EGL-X11 or GLX
+
+  if test x"$enable_egl_x11" != xno; then
+    if $PKG_CONFIG --exists egl ; then
+      AC_DEFINE(HAVE_EGL_X11, 1, [Use EGL-X11 instead of GLX])
+
+      X_PACKAGES="$X_PACKAGES egl"
+    elif test x"$enable_egl_x11" = xyes; then
+      AC_MSG_ERROR([EGL-X11 support requested but egl not found])
+    fi
+  fi
+
+  AM_CONDITIONAL(USE_EGL_X11, test "x$enable_egl_x11" != xno)
 
   if $have_base_x_pc ; then
     GDK_EXTRA_LIBS="$x_extra_libs"

--- a/configure.ac
+++ b/configure.ac
@@ -1947,11 +1947,6 @@ build/win32/vs9/Makefile
 build/win32/vs9/gtk3-version-paths.vsprops
 build/win32/vs10/Makefile
 build/win32/vs10/gtk3-version-paths.props
-build/win32/vs11/Makefile
-build/win32/vs12/Makefile
-build/win32/vs14/Makefile
-build/win32/vs15/Makefile
-build/win32/vs16/Makefile
 gdk/Makefile
 gdk/broadway/Makefile
 gdk/x11/Makefile

--- a/demos/Makefile.am
+++ b/demos/Makefile.am
@@ -3,7 +3,7 @@ include $(top_srcdir)/Makefile.decl
 
 SUBDIRS = gtk-demo widget-factory icon-browser
 
-EXTRA_DIST = \
+EXTRA_DIST += \
 	meson.build
 
 -include $(top_srcdir)/git.mk

--- a/demos/gtk-demo/Makefile.am
+++ b/demos/gtk-demo/Makefile.am
@@ -132,13 +132,14 @@ demos.h: $(demos) geninclude.pl
 demos.h.win32: $(demos_base) geninclude.pl
 	 $(AM_V_GEN) (here=`pwd` ; cd $(srcdir) && $(PERL) $$here/geninclude.pl $(demos_base)) > demos.h.win32
 
-nodist_gtk3_demo_SOURCES = demos.h
+nodist_gtk3_demo_SOURCES =	\
+	demos.h			\
+	demo_resources.c
 
 gtk3_demo_SOURCES = 		\
 	$(demos)		\
 	gtkfishbowl.c		\
 	gtkfishbowl.h		\
-	demo_resources.c	\
 	main.c
 
 gtk3_demo_DEPENDENCIES = $(DEPS)
@@ -146,8 +147,11 @@ gtk3_demo_LDADD = $(LDADDS)
 gtk3_demo_LDFLAGS = -export-dynamic
 
 gtk3_demo_application_SOURCES = \
-	application.c 		\
+	application.c
+nodist_gtk3_demo_application_SOURCES = \
 	demo_resources.c
+
+CLEANFILES = $(BUILT_SOURCES)
 
 gtk3_demo_application_LDADD = $(LDADDS)
 
@@ -189,10 +193,10 @@ uninstall-update-icon-cache:
 # ------------------- MSVC Build Items ----------------
 MSVCPROJS = gtk3-demo gtk3-demo-application
 
-gtk3_demo_FILES = $(gtk3_demo_SOURCES)
+gtk3_demo_FILES = $(gtk3_demo_SOURCES) $(nodist_gtk3_demo_SOURCES)
 gtk3_demo_EXCLUDES = font_features.c|pagesetup.c
 
-gtk3_demo_application_FILES = $(gtk3_demo_application_SOURCES)
+gtk3_demo_application_FILES = $(gtk3_demo_application_SOURCES) $(nodist_gtk3_demo_application_SOURCES)
 gtk3_demo_application_EXCLUDES = dummy
 
 include $(top_srcdir)/build/Makefile.msvcproj

--- a/demos/icon-browser/Makefile.am
+++ b/demos/icon-browser/Makefile.am
@@ -20,11 +20,12 @@ gtk3_icon_browser_SOURCES = \
 	main.c \
 	iconbrowserapp.c iconbrowserapp.h \
 	iconbrowserwin.c iconbrowserwin.h \
-	iconstore.c iconstore.h \
+	iconstore.c iconstore.h
+nodist_gtk3_icon_browser_SOURCES = \
 	resources.c
 
-BUILT_SOURCES = \
-	resources.c
+BUILT_SOURCES = $(nodist_gtk3_icon_browser_SOURCES)
+CLEANFILES = $(BUILT_SOURCES)
 
 resources.c: iconbrowser.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/iconbrowser.gresource.xml)
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $(srcdir)/iconbrowser.gresource.xml \
@@ -40,7 +41,7 @@ EXTRA_DIST = \
 # ------------------- MSVC Build Items ----------------
 MSVCPROJS = gtk3-icon-browser
 
-gtk3_icon_browser_FILES = $(gtk3_icon_browser_SOURCES)
+gtk3_icon_browser_FILES = $(gtk3_icon_browser_SOURCES) $(nodist_gtk3_icon_browser_SOURCES)
 gtk3_icon_browser_EXCLUDES = dummy
 
 include $(top_srcdir)/build/Makefile.msvcproj

--- a/demos/widget-factory/Makefile.am
+++ b/demos/widget-factory/Makefile.am
@@ -5,12 +5,11 @@ bin_PROGRAMS = gtk3-widget-factory
 desktopdir = $(datadir)/applications
 dist_desktop_DATA = gtk3-widget-factory.desktop
 
-gtk3_widget_factory_SOURCES = 		\
-	widget-factory.c		\
-	widget_factory_resources.c
+gtk3_widget_factory_SOURCES = widget-factory.c
+nodist_gtk3_widget_factory_SOURCES = widget_factory_resources.c
 
-BUILT_SOURCES = 			\
-	widget_factory_resources.c
+BUILT_SOURCES = $(nodist_gtk3_widget_factory_SOURCES)
+CLEANFILES = $(nodist_gtk3_widget_factory_SOURCES)
 
 gtk3_widget_factory_DEPENDENCIES = 	\
 	$(top_builddir)/gtk/libgtk-3.la

--- a/examples/application10/Makefile.am
+++ b/examples/application10/Makefile.am
@@ -16,7 +16,8 @@ exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
 	exampleappwin.c exampleappwin.h 	\
-	exampleappprefs.c exampleappprefs.h 	\
+	exampleappprefs.c exampleappprefs.h
+nodist_exampleapp_SOURCES =			\
 	resources.c
 
 BUILT_SOURCES = 				\
@@ -45,6 +46,7 @@ EXTRA_DIST = 					\
 	meson.build
 
 CLEANFILES = 					\
+	$(nodist_exampleapp_SOURCES)		\
 	gschemas.compiled
 
 -include $(top_srcdir)/git.mk

--- a/examples/application2/Makefile.am
+++ b/examples/application2/Makefile.am
@@ -15,10 +15,11 @@ exampleapp_LDADD = $(GTK_LIBS)
 exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
-	exampleappwin.c exampleappwin.h 	\
+	exampleappwin.c exampleappwin.h
+nodist_exampleapp_SOURCES =			\
 	resources.c
 
-BUILT_SOURCES = resources.c
+BUILT_SOURCES = $(nodist_exampleapp_SOURCES)
 
 resources.c: exampleapp.gresource.xml window.ui
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $(srcdir)/exampleapp.gresource.xml \
@@ -28,5 +29,7 @@ EXTRA_DIST = 					\
 	window.ui 				\
 	exampleapp.gresource.xml	\
 	meson.build
+
+CLEANFILES = $(BUILT_SOURCES)
 
 -include $(top_srcdir)/git.mk

--- a/examples/application3/Makefile.am
+++ b/examples/application3/Makefile.am
@@ -15,10 +15,11 @@ exampleapp_LDADD = $(GTK_LIBS)
 exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
-	exampleappwin.c exampleappwin.h 	\
+	exampleappwin.c exampleappwin.h
+nodist_exampleapp_SOURCES =			\
 	resources.c
 
-BUILT_SOURCES = resources.c
+BUILT_SOURCES = $(nodist_exampleapp_SOURCES)
 
 resources.c: exampleapp.gresource.xml window.ui
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $(srcdir)/exampleapp.gresource.xml \
@@ -28,5 +29,7 @@ EXTRA_DIST = 					\
 	window.ui 				\
 	exampleapp.gresource.xml	\
 	meson.build
+
+CLEANFILES = $(BUILT_SOURCES)
 
 -include $(top_srcdir)/git.mk

--- a/examples/application4/Makefile.am
+++ b/examples/application4/Makefile.am
@@ -15,10 +15,11 @@ exampleapp_LDADD = $(GTK_LIBS)
 exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
-	exampleappwin.c exampleappwin.h 	\
+	exampleappwin.c exampleappwin.h
+nodist_exampleapp_SOURCES =			\
 	resources.c
 
-BUILT_SOURCES = resources.c
+BUILT_SOURCES = $(nodist_exampleapp_SOURCES)
 
 resources.c: exampleapp.gresource.xml window.ui app-menu.ui
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) $(srcdir)/exampleapp.gresource.xml \
@@ -29,5 +30,7 @@ EXTRA_DIST = 					\
 	app-menu.ui 				\
 	exampleapp.gresource.xml	\
 	meson.build
+
+CLEANFILES = $(BUILT_SOURCES)
 
 -include $(top_srcdir)/git.mk

--- a/examples/application5/Makefile.am
+++ b/examples/application5/Makefile.am
@@ -15,7 +15,8 @@ exampleapp_LDADD = $(GTK_LIBS)
 exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
-	exampleappwin.c exampleappwin.h 	\
+	exampleappwin.c exampleappwin.h
+nodist_exampleapp_SOURCES = 			\
 	resources.c
 
 BUILT_SOURCES = 				\
@@ -42,6 +43,7 @@ EXTRA_DIST = 					\
 	meson.build
 
 CLEANFILES = 					\
+	$(nodist_exampleapp_SOURCES)		\
 	gschemas.compiled
 
 -include $(top_srcdir)/git.mk

--- a/examples/application6/Makefile.am
+++ b/examples/application6/Makefile.am
@@ -16,7 +16,8 @@ exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
 	exampleappwin.c exampleappwin.h 	\
-	exampleappprefs.c exampleappprefs.h 	\
+	exampleappprefs.c exampleappprefs.h
+nodist_exampleapp_SOURCES = 			\
 	resources.c
 
 BUILT_SOURCES = 				\
@@ -44,6 +45,7 @@ EXTRA_DIST = 					\
 	meson.build
 
 CLEANFILES = 					\
+	$(nodist_exampleapp_SOURCES)		\
 	gschemas.compiled
 
 -include $(top_srcdir)/git.mk

--- a/examples/application7/Makefile.am
+++ b/examples/application7/Makefile.am
@@ -16,7 +16,8 @@ exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
 	exampleappwin.c exampleappwin.h 	\
-	exampleappprefs.c exampleappprefs.h 	\
+	exampleappprefs.c exampleappprefs.h
+nodist_exampleapp_SOURCES =			\
 	resources.c
 
 BUILT_SOURCES = 				\
@@ -44,6 +45,7 @@ EXTRA_DIST = 					\
 	meson.build
 
 CLEANFILES = 					\
+	$(nodist_exampleapp_SOURCES)		\
 	gschemas.compiled
 
 -include $(top_srcdir)/git.mk

--- a/examples/application8/Makefile.am
+++ b/examples/application8/Makefile.am
@@ -16,7 +16,8 @@ exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
 	exampleappwin.c exampleappwin.h 	\
-	exampleappprefs.c exampleappprefs.h 	\
+	exampleappprefs.c exampleappprefs.h
+nodist_exampleapp_SOURCES =			\
 	resources.c
 
 BUILT_SOURCES = 				\
@@ -45,6 +46,7 @@ EXTRA_DIST = 					\
 	meson.build
 
 CLEANFILES = 					\
+	$(nodist_exampleapp_SOURCES)		\
 	gschemas.compiled
 
 -include $(top_srcdir)/git.mk

--- a/examples/application9/Makefile.am
+++ b/examples/application9/Makefile.am
@@ -16,7 +16,8 @@ exampleapp_SOURCES = 				\
 	main.c 					\
 	exampleapp.c exampleapp.h 		\
 	exampleappwin.c exampleappwin.h 	\
-	exampleappprefs.c exampleappprefs.h 	\
+	exampleappprefs.c exampleappprefs.h
+nodist_exampleapp_SOURCES =			\
 	resources.c
 
 BUILT_SOURCES = 				\
@@ -45,6 +46,7 @@ EXTRA_DIST = 					\
 	meson.build
 
 CLEANFILES = 					\
+	$(nodist_exampleapp_SOURCES)		\
 	gschemas.compiled
 
 -include $(top_srcdir)/git.mk

--- a/gdk/Makefile.am
+++ b/gdk/Makefile.am
@@ -203,16 +203,8 @@ nodist_gdkinclude_HEADERS = gdkconfig.h gdkenumtypes.h gdkversionmacros.h
 deprecatedincludedir = $(includedir)/gtk-3.0/gdk/deprecated
 deprecatedinclude_HEADERS = $(deprecated_h_sources)
 
-common_sources = 		\
-	$(gdk_private_headers)	\
-	$(gdk_c_sources)	\
-	gdkenumtypes.c		\
-	gdkmarshalers.c		\
-	gdkmarshalers.h		\
-	gdkresources.h		\
-	gdkresources.c
-
-libgdk_3_la_SOURCES = $(common_sources)
+libgdk_3_la_SOURCES = $(gdk_private_headers) $(gdk_c_sources)
+nodist_libgdk_3_la_SOURCES = $(gdk_built_sources)
 libgdk_3_la_CFLAGS = $(AM_CFLAGS) $(GDK_HIDDEN_VISIBILITY_CFLAGS)
 libgdk_3_la_LIBADD = $(GDK_DEP_LIBS) $(SHM_LIBS)
 libgdk_3_la_LDFLAGS = $(LDADD)
@@ -413,10 +405,8 @@ endif
 
 lib_LTLIBRARIES = libgdk-3.la
 
-MAINTAINERCLEANFILES = $(gdk_built_sources) stamp-gdkenumtypes.h
-EXTRA_DIST += \
-	$(gdk_built_sources)	\
-	fallback-c89.c
+DISTCLEANFILES = $(gdk_built_sources) stamp-gdkenumtypes.h
+EXTRA_DIST += fallback-c89.c
 
 install-exec-hook:
 if DISABLE_EXPLICIT_DEPS
@@ -500,7 +490,7 @@ gdkresources.c: gdk.gresource.xml $(resource_files)
 # ------------------- MSVC Build Items ----------------
 MSVCPROJS = gdk-3
 
-gdk_3_FILES = $(libgdk_3_la_SOURCES)
+gdk_3_FILES = $(libgdk_3_la_SOURCES) $(nodist_libgdk_3_la_SOURCES)
 gdk_3_EXCLUDES = dummy
 gdk_3_HEADERS_DIR = $(gdkincludedir)
 
@@ -554,19 +544,12 @@ dist-hook: \
 	$(top_builddir)/build/win32/vs9/gdk-3.headers	\
 	$(INTROSPECTION_INTERMEDIATE_ITEMS)
 
-DISTCLEANFILES = gdkconfig.h stamp-gc-h
+DISTCLEANFILES += gdkconfig.h stamp-gc-h
 
 install-data-local: install-ms-lib install-def-file
 
 uninstall-local: uninstall-ms-lib uninstall-def-file
 	rm -f $(DESTDIR)$(configexecincludedir)/gdkconfig.h
-
-# if srcdir!=builddir, clean out maintainer-clean files from builddir
-# this allows dist to pass.
-distclean-local:
-	if test $(srcdir) != .; then \
-	  rm -f $(MAINTAINERCLEANFILES); \
-	fi
 
 .PHONY: files
 

--- a/gdk/gdkdisplay.c
+++ b/gdk/gdkdisplay.c
@@ -2199,6 +2199,28 @@ gdk_display_notify_startup_complete (GdkDisplay  *display,
   GDK_DISPLAY_GET_CLASS (display)->notify_startup_complete (display, startup_id);
 }
 
+/**
+ * gdk_display_get_startup_notification_id:
+ * @display: (type GdkX11Display): a #GdkDisplay
+ *
+ * Gets the startup notification ID for a display, or %NULL
+ * if no ID has been defined.
+ *
+ * Returns: the startup notification ID for @display, or %NULL
+ *
+ * Since: 3.22
+ */
+const gchar *
+gdk_display_get_startup_notification_id (GdkDisplay *display)
+{
+  g_return_val_if_fail (GDK_IS_DISPLAY (display), NULL);
+
+  if (GDK_DISPLAY_GET_CLASS (display)->get_startup_notification_id == NULL)
+    return NULL;
+
+  return GDK_DISPLAY_GET_CLASS (display)->get_startup_notification_id (display);
+}
+
 void
 _gdk_display_pause_events (GdkDisplay *display)
 {

--- a/gdk/gdkdisplay.h
+++ b/gdk/gdkdisplay.h
@@ -166,6 +166,8 @@ gboolean gdk_display_supports_composite        (GdkDisplay    *display);
 GDK_AVAILABLE_IN_ALL
 void     gdk_display_notify_startup_complete   (GdkDisplay    *display,
                                                 const gchar   *startup_id);
+GDK_AVAILABLE_IN_3_22
+const gchar * gdk_display_get_startup_notification_id (GdkDisplay *display);
 
 GDK_DEPRECATED_IN_3_20_FOR(gdk_display_get_default_seat)
 GdkDeviceManager * gdk_display_get_device_manager (GdkDisplay *display);

--- a/gdk/gdkdisplayprivate.h
+++ b/gdk/gdkdisplayprivate.h
@@ -186,6 +186,7 @@ struct _GdkDisplayClass
 
   void                       (*notify_startup_complete) (GdkDisplay  *display,
                                                          const gchar *startup_id);
+  const gchar *              (*get_startup_notification_id) (GdkDisplay  *display);
   void                       (*event_data_copy) (GdkDisplay     *display,
                                                  const GdkEvent *event,
                                                  GdkEvent       *new_event);

--- a/gdk/gdkgl.c
+++ b/gdk/gdkgl.c
@@ -644,25 +644,6 @@ gdk_cairo_draw_from_gl (cairo_t              *cr,
   else
     {
       /* Software fallback */
-      int major, minor, version;
-      gboolean es_read_bgra = FALSE;
-
-#ifdef GDK_WINDOWING_WIN32
-      /* on ANGLE GLES, we need to set the glReadPixel() format as GL_BGRA instead */
-      if (GDK_WIN32_IS_GL_CONTEXT(paint_context))
-        es_read_bgra = TRUE;
-#endif
-
-      gdk_gl_context_get_version (paint_context, &major, &minor);
-      version = major * 100 + minor;
-
-      /* TODO: Use glTexSubImage2D() and do a row-by-row copy to replace
-       * the GL_UNPACK_ROW_LENGTH support
-       */
-      if (gdk_gl_context_get_use_es (paint_context) &&
-          !(version >= 300 || gdk_gl_context_has_unpack_subimage (paint_context)))
-        goto out;
-
       /* TODO: avoid reading back non-required data due to dest clip */
       image = cairo_surface_create_similar_image (cairo_get_target (cr),
                                                   (alpha_size == 0) ? CAIRO_FORMAT_RGB24 : CAIRO_FORMAT_ARGB32,
@@ -686,24 +667,15 @@ gdk_cairo_draw_from_gl (cairo_t              *cr,
                                      GL_TEXTURE_2D, source, 0);
         }
 
-      glPixelStorei (GL_PACK_ALIGNMENT, 4);
-      glPixelStorei (GL_PACK_ROW_LENGTH, cairo_image_surface_get_stride (image) / 4);
-
-      /* The implicit format conversion is going to make this path slower */
-      if (!gdk_gl_context_get_use_es (paint_context))
-        glReadPixels (x, y, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
-                      cairo_image_surface_get_data (image));
-      else
-        glReadPixels (x, y, width, height, es_read_bgra ? GL_BGRA : GL_RGBA, GL_UNSIGNED_BYTE,
-                      cairo_image_surface_get_data (image));
-
-      glPixelStorei (GL_PACK_ROW_LENGTH, 0);
+      gdk_gl_context_download_texture (paint_context,
+                                       x, y, width, height,
+                                       image);
 
       glBindFramebufferEXT (GL_FRAMEBUFFER_EXT, 0);
 
       cairo_surface_mark_dirty (image);
 
-      /* Invert due to opengl having different origin */
+      /* Invert due to GL framebuffers having different origin */
       cairo_scale (cr, 1, -1);
       cairo_translate (cr, 0, -height / buffer_scale);
 
@@ -714,10 +686,8 @@ gdk_cairo_draw_from_gl (cairo_t              *cr,
       cairo_surface_destroy (image);
     }
 
-out:
   if (clip_region)
     cairo_region_destroy (clip_region);
-
 }
 
 /* This is always called with the paint context current */

--- a/gdk/gdkglcontext.c
+++ b/gdk/gdkglcontext.c
@@ -237,6 +237,57 @@ gdk_gl_context_get_property (GObject    *gobject,
 }
 
 void
+gdk_gl_context_download_texture (GdkGLContext    *context,
+                                 int              x,
+                                 int              y,
+                                 int              width,
+                                 int              height,
+                                 cairo_surface_t *image_surface)
+{
+  GdkGLContextPrivate *priv = gdk_gl_context_get_instance_private (context);
+
+  g_return_if_fail (GDK_IS_GL_CONTEXT (context));
+
+  /* GL_UNPACK_ROW_LENGTH is available on desktop GL, OpenGL ES >= 3.0, or if
+   * the GL_EXT_unpack_subimage extension for OpenGL ES 2.0 is available
+   */
+  if (!priv->use_es ||
+      (priv->use_es && (priv->gl_version >= 30 || priv->has_unpack_subimage)))
+    {
+      glPixelStorei (GL_PACK_ALIGNMENT, 4);
+      glPixelStorei (GL_PACK_ROW_LENGTH, cairo_image_surface_get_stride (image_surface) / 4);
+
+      if (priv->use_es)
+        glReadPixels (x, y, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                      cairo_image_surface_get_data (image_surface));
+      else
+        glReadPixels (x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
+                      cairo_image_surface_get_data (image_surface));
+
+      glPixelStorei (GL_PACK_ROW_LENGTH, 0);
+    }
+  else
+    {
+      GLvoid *data = cairo_image_surface_get_data (image_surface);
+      int stride = cairo_image_surface_get_stride (image_surface);
+      int i;
+
+      if (priv->use_es)
+        {
+          for (i = y; i < height; i++)
+            glReadPixels (x, i, width, 1, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                          (unsigned char *) data + (i * stride));
+        }
+      else
+        {
+          for (i = y; i < height; i++)
+            glReadPixels (x, i, width, 1, GL_RGBA, GL_UNSIGNED_BYTE,
+                          (unsigned char *) data + (i * stride));
+        }
+    }
+}
+
+void
 gdk_gl_context_upload_texture (GdkGLContext    *context,
                                cairo_surface_t *image_surface,
                                int              width,

--- a/gdk/gdkglcontextprivate.h
+++ b/gdk/gdkglcontextprivate.h
@@ -81,6 +81,12 @@ void                    gdk_gl_context_upload_texture           (GdkGLContext   
                                                                  int              width,
                                                                  int              height,
                                                                  guint            texture_target);
+void                    gdk_gl_context_download_texture         (GdkGLContext    *context,
+                                                                 int              x,
+                                                                 int              y,
+                                                                 int              width,
+                                                                 int              height,
+                                                                 cairo_surface_t *image_surface);
 GdkGLContextPaintData * gdk_gl_context_get_paint_data           (GdkGLContext    *context);
 gboolean                gdk_gl_context_use_texture_rectangle    (GdkGLContext    *context);
 gboolean                gdk_gl_context_has_framebuffer_blit     (GdkGLContext    *context);

--- a/gdk/gdkmonitor.c
+++ b/gdk/gdkmonitor.c
@@ -526,6 +526,25 @@ gdk_monitor_set_connector (GdkMonitor *monitor,
 }
 
 void
+gdk_monitor_update_workarea (GdkMonitor *monitor)
+{
+  GdkRectangle workarea;
+  GdkScreen *screen;
+
+  /* screen will be NULL during initialization */
+  screen = gdk_display_get_default_screen (monitor->display);
+  if (!screen)
+    return;
+
+  gdk_monitor_get_workarea (monitor, &workarea);
+  if (gdk_rectangle_equal (&workarea, &monitor->workarea))
+    return;
+
+  monitor->workarea = workarea;
+  g_object_notify (G_OBJECT (monitor), "workarea");
+}
+
+void
 gdk_monitor_set_position (GdkMonitor *monitor,
                           int         x,
                           int         y)

--- a/gdk/gdkmonitorprivate.h
+++ b/gdk/gdkmonitorprivate.h
@@ -38,6 +38,7 @@ struct _GdkMonitor {
   char *model;
   char *connector;
   GdkRectangle geometry;
+  GdkRectangle workarea;
   int width_mm;
   int height_mm;
   int scale_factor;
@@ -76,6 +77,7 @@ void            gdk_monitor_set_refresh_rate    (GdkMonitor *monitor,
                                                  int         refresh_rate);
 void            gdk_monitor_set_subpixel_layout (GdkMonitor        *monitor,
                                                  GdkSubpixelLayout  subpixel);
+void            gdk_monitor_update_workarea     (GdkMonitor *monitor);
 void            gdk_monitor_invalidate          (GdkMonitor *monitor);
 
 G_END_DECLS

--- a/gdk/wayland/gdkdisplay-wayland.c
+++ b/gdk/wayland/gdkdisplay-wayland.c
@@ -903,6 +903,23 @@ gdk_wayland_display_get_next_serial (GdkDisplay *display)
 }
 
 /**
+ * gdk_wayland_display_get_startup_notification_id:
+ * @display: (type GdkX11Display): a #GdkDisplay
+ *
+ * Gets the startup notification ID for a Wayland display, or %NULL
+ * if no ID has been defined.
+ *
+ * Returns: the startup notification ID for @display, or %NULL
+ *
+ * Since: 3.22
+ */
+const gchar *
+gdk_wayland_display_get_startup_notification_id (GdkDisplay  *display)
+{
+  return GDK_WAYLAND_DISPLAY (display)->startup_notification_id;
+}
+
+/**
  * gdk_wayland_display_set_startup_notification_id:
  * @display: (type GdkWaylandDisplay): a #GdkDisplay
  * @startup_id: the startup notification ID (must be valid utf8)
@@ -1064,6 +1081,7 @@ gdk_wayland_display_class_init (GdkWaylandDisplayClass *class)
   display_class->before_process_all_updates = gdk_wayland_display_before_process_all_updates;
   display_class->after_process_all_updates = gdk_wayland_display_after_process_all_updates;
   display_class->get_next_serial = gdk_wayland_display_get_next_serial;
+  display_class->get_startup_notification_id = gdk_wayland_display_get_startup_notification_id;
   display_class->notify_startup_complete = gdk_wayland_display_notify_startup_complete;
   display_class->create_window_impl = _gdk_wayland_display_create_window_impl;
   display_class->get_keymap = _gdk_wayland_display_get_keymap;

--- a/gdk/wayland/gdkwaylanddisplay.h
+++ b/gdk/wayland/gdkwaylanddisplay.h
@@ -54,6 +54,8 @@ void                    gdk_wayland_display_set_cursor_theme    (GdkDisplay  *di
                                                                  const gchar *theme,
                                                                  gint         size);
 GDK_AVAILABLE_IN_3_22
+const gchar *           gdk_wayland_display_get_startup_notification_id (GdkDisplay *display);
+GDK_AVAILABLE_IN_3_22
 void                    gdk_wayland_display_set_startup_notification_id (GdkDisplay *display,
                                                                          const char *startup_id);
 

--- a/gdk/x11/Makefile.am
+++ b/gdk/x11/Makefile.am
@@ -40,7 +40,6 @@ libgdk_x11_la_SOURCES = 	\
 	gdkeventtranslator.c	\
 	gdkeventtranslator.h	\
 	gdkgeometry-x11.c  	\
-	gdkglcontext-x11.c	\
 	gdkglcontext-x11.h	\
 	gdkkeys-x11.c		\
 	gdkmain-x11.c		\
@@ -60,6 +59,12 @@ libgdk_x11_la_SOURCES = 	\
 	gdkprivate-x11.h	\
 	xsettings-client.h	\
 	xsettings-client.c
+
+if USE_EGL_X11
+libgdk_x11_la_SOURCES += gdkglcontext-x11-eglx.c
+else
+libgdk_x11_la_SOURCES += gdkglcontext-x11.c
+endif
 
 libgdkinclude_HEADERS = 	\
 	gdkx.h

--- a/gdk/x11/gdkdisplay-x11.c
+++ b/gdk/x11/gdkdisplay-x11.c
@@ -3212,6 +3212,7 @@ gdk_x11_display_class_init (GdkX11DisplayClass * class)
   display_class->before_process_all_updates = _gdk_x11_display_before_process_all_updates;
   display_class->after_process_all_updates = _gdk_x11_display_after_process_all_updates;
   display_class->get_next_serial = gdk_x11_display_get_next_serial;
+  display_class->get_startup_notification_id = gdk_x11_display_get_startup_notification_id;
   display_class->notify_startup_complete = gdk_x11_display_notify_startup_complete;
   display_class->create_window_impl = _gdk_x11_display_create_window_impl;
   display_class->get_keymap = gdk_x11_display_get_keymap;

--- a/gdk/x11/gdkdisplay-x11.c
+++ b/gdk/x11/gdkdisplay-x11.c
@@ -1103,6 +1103,9 @@ gdk_x11_display_translate_event (GdkEventTranslator *translator,
       if (toplevel && xevent->xproperty.atom == gdk_x11_get_xatom_by_name_for_display (display, "_GTK_WINDOW_UNREDIRECTED"))
         gdk_check_window_unredirected (display, toplevel, window, xevent->xproperty.atom);
 
+      if (xevent->xproperty.atom == gdk_x11_get_xatom_by_name_for_display (display, "_NET_WORKAREA"))
+	_gdk_x11_screen_size_changed (screen, xevent);
+
       if (window->event_mask & GDK_PROPERTY_CHANGE_MASK)
 	{
 	  event->property.type = GDK_PROPERTY_NOTIFY;

--- a/gdk/x11/gdkdisplay-x11.h
+++ b/gdk/x11/gdkdisplay-x11.h
@@ -137,18 +137,19 @@ struct _GdkX11Display
 
   guint server_time_is_monotonic_time : 1;
 
-  guint have_glx : 1;
+  guint supports_gl : 1;
 
-  /* GLX extensions we check */
-  guint has_glx_swap_interval : 1;
-  guint has_glx_create_context : 1;
-  guint has_glx_texture_from_pixmap : 1;
-  guint has_glx_video_sync : 1;
-  guint has_glx_buffer_age : 1;
-  guint has_glx_sync_control : 1;
-  guint has_glx_multisample : 1;
-  guint has_glx_visual_rating : 1;
-  guint has_glx_create_es2_context : 1;
+  /* Platform-specific GL extensions we check */
+  guint has_swap_interval : 1;
+  guint has_create_context : 1;
+  guint has_texture_from_pixmap : 1;
+  guint has_video_sync : 1;
+  guint has_buffer_age : 1;
+  guint has_sync_control : 1;
+  guint has_multisample : 1;
+  guint has_visual_rating : 1;
+  guint has_create_es2_context : 1;
+  guint has_swap_buffers_with_damage : 1;
 };
 
 struct _GdkX11DisplayClass

--- a/gdk/x11/gdkdisplay-x11.h
+++ b/gdk/x11/gdkdisplay-x11.h
@@ -150,6 +150,7 @@ struct _GdkX11Display
   guint has_visual_rating : 1;
   guint has_create_es2_context : 1;
   guint has_swap_buffers_with_damage : 1;
+  guint has_image_pixmap : 1;
 };
 
 struct _GdkX11DisplayClass

--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -446,13 +446,14 @@ gdk_x11_gl_context_realize (GdkGLContext  *context,
   legacy_bit = !display_x11->has_create_context ||
                (_gdk_gl_flags & GDK_GL_LEGACY) != 0;
 
-  es_bit = ((_gdk_gl_flags & GDK_GL_GLES) != 0 ||
-            (share != NULL && gdk_gl_context_get_use_es (share)));
+  /* XXX: Force GLES */
+  es_bit =  TRUE;
 
   if (es_bit)
     {
+      /* XXX: Force GLES 2.0 */
       context_attrs[0] = EGL_CONTEXT_CLIENT_VERSION;
-      context_attrs[1] = major == 3 ? 3 : 2;
+      context_attrs[1] = 2;
       context_attrs[2] = EGL_NONE;
 
       eglBindAPI (EGL_OPENGL_ES_API);
@@ -490,7 +491,7 @@ gdk_x11_gl_context_realize (GdkGLContext  *context,
 
   GDK_NOTE (OPENGL,
             g_message ("Creating EGL context (version:%d.%d, debug:%s, forward:%s, legacy:%s, es:%s)",
-                       major, minor,
+                       2, 0,
                        debug_bit ? "yes" : "no",
                        compat_bit ? "yes" : "no",
                        legacy_bit ? "yes" : "no",
@@ -606,7 +607,7 @@ gdk_x11_display_init_gl (GdkDisplay *display)
   if (!eglInitialize (edpy, &major, &minor))
     return FALSE;
 
-  if (!eglBindAPI (EGL_OPENGL_API))
+  if (!eglBindAPI (EGL_OPENGL_ES_API))
     return FALSE;
 
   display_x11->supports_gl = TRUE;

--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -1,0 +1,865 @@
+/* GDK - The GIMP Drawing Kit
+ *
+ * gdkglcontext-x11.c: X11 specific OpenGL wrappers
+ *
+ * Copyright © 2014  Emmanuele Bassi
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "gdkglcontext-x11.h"
+#include "gdkdisplay-x11.h"
+#include "gdkscreen-x11.h"
+
+#include "gdkx11display.h"
+#include "gdkx11glcontext.h"
+#include "gdkx11screen.h"
+#include "gdkx11window.h"
+#include "gdkx11visual.h"
+#include "gdkvisualprivate.h"
+#include "gdkx11property.h"
+#include <X11/Xatom.h>
+
+#include "gdkinternals.h"
+
+#include "gdkintl.h"
+
+#include <cairo/cairo-xlib.h>
+
+#include <epoxy/egl.h>
+
+struct _GdkX11GLContext
+{
+  GdkGLContext parent_instance;
+
+  EGLDisplay egl_display;
+  EGLContext egl_context;
+  EGLConfig egl_config;
+
+  guint is_attached : 1;
+  guint do_frame_sync : 1;
+};
+
+struct _GdkX11GLContextClass
+{
+  GdkGLContextClass parent_class;
+};
+
+typedef struct {
+  EGLDisplay egl_display;
+  EGLConfig egl_config;
+  EGLSurface egl_surface;
+} DrawableInfo;
+
+static gboolean gdk_x11_display_init_gl (GdkDisplay *display);
+
+G_DEFINE_TYPE (GdkX11GLContext, gdk_x11_gl_context, GDK_TYPE_GL_CONTEXT)
+
+static EGLDisplay
+gdk_x11_display_get_egl_display (GdkDisplay *display)
+{
+  EGLDisplay dpy = NULL;
+
+  dpy = g_object_get_data (G_OBJECT (display), "-gdk-x11-egl-display");
+  if (dpy != NULL)
+    return dpy;
+
+  if (epoxy_has_egl_extension (NULL, "EGL_KHR_platform_base"))
+    {
+      PFNEGLGETPLATFORMDISPLAYPROC getPlatformDisplay =
+        (void *) eglGetProcAddress ("eglGetPlatformDisplay");
+
+      if (getPlatformDisplay)
+        dpy = getPlatformDisplay (EGL_PLATFORM_X11_KHR,
+                                  gdk_x11_display_get_xdisplay (display),
+                                  NULL);
+      if (dpy != NULL)
+        goto out;
+    }
+
+  if (epoxy_has_egl_extension (NULL, "EGL_EXT_platform_base"))
+    {
+      PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplay =
+        (void *) eglGetProcAddress ("eglGetPlatformDisplayEXT");
+
+      if (getPlatformDisplay)
+        dpy = getPlatformDisplay (EGL_PLATFORM_X11_EXT,
+                                  gdk_x11_display_get_xdisplay (display),
+                                  NULL);
+      if (dpy != NULL)
+        goto out;
+    }
+
+  dpy = eglGetDisplay ((EGLNativeDisplayType) gdk_x11_display_get_xdisplay (display));
+
+out:
+  if (dpy != NULL)
+    g_object_set_data (G_OBJECT (display), "-gdk-x11-egl-display", dpy);
+
+  return dpy;
+}
+
+typedef struct {
+  EGLDisplay egl_display;
+  EGLConfig egl_config;
+  EGLSurface egl_surface;
+
+  Display *xdisplay;
+  Window dummy_xwin;
+  XVisualInfo *xvisinfo;
+} DummyInfo;
+
+static void
+dummy_info_free (gpointer data)
+{
+  DummyInfo *info = data;
+
+  if (data == NULL)
+    return;
+
+  if (info->egl_surface != NULL)
+    {
+      eglDestroySurface (info->egl_display, info->egl_surface);
+      info->egl_surface = NULL;
+    }
+
+  if (info->dummy_xwin != None)
+    {
+      XDestroyWindow (info->xdisplay, info->dummy_xwin);
+      info->dummy_xwin = None;
+    }
+
+  if (info->xvisinfo != NULL)
+    {
+      XFree (info->xvisinfo);
+      info->xvisinfo = NULL;
+    }
+
+  g_slice_free (DummyInfo, info);
+}
+
+static XVisualInfo *
+get_visual_info_for_egl_config (GdkDisplay *display,
+                                EGLConfig   egl_config)
+{
+  XVisualInfo visinfo_template;
+  int template_mask = 0;
+  XVisualInfo *visinfo = NULL;
+  int visinfos_count;
+  EGLint visualid, red_size, green_size, blue_size, alpha_size;
+  EGLDisplay egl_display = gdk_x11_display_get_egl_display (display);
+
+  eglGetConfigAttrib (egl_display, egl_config, EGL_NATIVE_VISUAL_ID, &visualid);
+
+  if (visualid != 0)
+    {
+      visinfo_template.visualid = visualid;
+      template_mask |= VisualIDMask;
+    }
+  else
+    {
+      /* some EGL drivers don't implement the EGL_NATIVE_VISUAL_ID
+       * attribute, so attempt to find the closest match.
+       */
+
+      eglGetConfigAttrib (egl_display, egl_config, EGL_RED_SIZE, &red_size);
+      eglGetConfigAttrib (egl_display, egl_config, EGL_GREEN_SIZE, &green_size);
+      eglGetConfigAttrib (egl_display, egl_config, EGL_BLUE_SIZE, &blue_size);
+      eglGetConfigAttrib (egl_display, egl_config, EGL_ALPHA_SIZE, &alpha_size);
+
+      visinfo_template.depth = red_size + green_size + blue_size + alpha_size;
+      template_mask |= VisualDepthMask;
+
+      visinfo_template.screen = DefaultScreen (gdk_x11_display_get_xdisplay (display));
+      template_mask |= VisualScreenMask;
+    }
+
+  visinfo = XGetVisualInfo (gdk_x11_display_get_xdisplay (display),
+                            template_mask,
+                            &visinfo_template,
+                            &visinfos_count);
+
+  if (visinfos_count < 1)
+    return NULL;
+
+  return visinfo;
+}
+
+static EGLSurface
+gdk_x11_display_get_egl_dummy_surface (GdkDisplay *display,
+                                       EGLConfig   egl_config)
+{
+  DummyInfo *info;
+  XVisualInfo *xvisinfo;
+  XSetWindowAttributes attrs;
+
+  info = g_object_get_data (G_OBJECT (display), "-gdk-x11-egl-dummy-surface");
+  if (info != NULL)
+    return info->egl_surface;
+
+  xvisinfo = get_visual_info_for_egl_config (display, egl_config);
+  if (xvisinfo == NULL)
+    return NULL;
+
+  info = g_slice_new (DummyInfo);
+  info->xdisplay = gdk_x11_display_get_xdisplay (display);
+  info->xvisinfo = xvisinfo;
+  info->egl_display = gdk_x11_display_get_egl_display (display);
+  info->egl_config = egl_config;
+
+  attrs.override_redirect = True;
+  attrs.colormap = XCreateColormap (info->xdisplay,
+                                    DefaultRootWindow (info->xdisplay),
+                                    xvisinfo->visual,
+                                    AllocNone);
+  attrs.border_pixel = 0;
+
+  info->dummy_xwin =
+    XCreateWindow (info->xdisplay,
+                   DefaultRootWindow (info->xdisplay),
+                   -100, -100, 1, 1,
+                   0,
+                   xvisinfo->depth,
+                   CopyFromParent,
+                   xvisinfo->visual,
+                   CWOverrideRedirect | CWColormap | CWBorderPixel,
+                   &attrs);
+
+  info->egl_surface =
+    eglCreateWindowSurface (info->egl_display,
+                            info->egl_config,
+                            (EGLNativeWindowType) info->dummy_xwin,
+                            NULL);
+
+  g_object_set_data_full (G_OBJECT (display), "-gdk-x11-egl-dummy-surface",
+                          info,
+                          dummy_info_free);
+
+  return info->egl_surface;
+}
+
+static void
+drawable_info_free (gpointer data)
+{
+  DrawableInfo *info = data;
+
+  if (data == NULL)
+    return;
+
+  if (info->egl_surface != NULL)
+    {
+      eglDestroySurface (info->egl_display, info->egl_surface);
+      info->egl_surface = NULL;
+    }
+
+  g_slice_free (DrawableInfo, data);
+}
+
+static EGLSurface
+gdk_x11_window_get_egl_surface (GdkWindow *window,
+                                EGLConfig  config)
+{
+  GdkDisplay *display = gdk_window_get_display (window);
+  EGLDisplay egl_display = gdk_x11_display_get_egl_display (display);
+  DrawableInfo *info;
+
+  info = g_object_get_data (G_OBJECT (window), "-gdk-x11-egl-drawable");
+  if (info != NULL)
+    return info->egl_surface;
+
+  info = g_slice_new (DrawableInfo);
+  info->egl_display = egl_display;
+  info->egl_config = config;
+  info->egl_surface =
+    eglCreateWindowSurface (info->egl_display, config,
+                            (EGLNativeWindowType) gdk_x11_window_get_xid (window),
+                            NULL);
+
+  g_object_set_data_full (G_OBJECT (window), "-gdk-x11-egl-drawable",
+                          info,
+                          drawable_info_free);
+
+  return info->egl_surface;
+}
+
+void
+gdk_x11_window_invalidate_for_new_frame (GdkWindow      *window,
+                                         cairo_region_t *update_area)
+{
+  cairo_rectangle_int_t window_rect;
+  GdkDisplay *display = gdk_window_get_display (window);
+  GdkX11Display *display_x11 = GDK_X11_DISPLAY (display);
+  GdkX11GLContext *context_x11;
+  EGLint buffer_age;
+  gboolean invalidate_all;
+
+  /* Minimal update is ok if we're not drawing with gl */
+  if (window->gl_paint_context == NULL)
+    return;
+
+  context_x11 = GDK_X11_GL_CONTEXT (window->gl_paint_context);
+
+  buffer_age = 0;
+
+  if (display_x11->has_buffer_age)
+    {
+      gdk_gl_context_make_current (window->gl_paint_context);
+
+      eglQuerySurface (gdk_x11_display_get_egl_display (display),
+                       gdk_x11_window_get_egl_surface (window, context_x11->egl_config),
+                       EGL_BUFFER_AGE_EXT,
+                       &buffer_age);
+    }
+
+
+  invalidate_all = FALSE;
+  if (buffer_age == 0 || buffer_age >= 4)
+    {
+      invalidate_all = TRUE;
+    }
+  else
+    {
+      if (buffer_age >= 2)
+        {
+          if (window->old_updated_area[0])
+            cairo_region_union (update_area, window->old_updated_area[0]);
+          else
+            invalidate_all = TRUE;
+        }
+      if (buffer_age >= 3)
+        {
+          if (window->old_updated_area[1])
+            cairo_region_union (update_area, window->old_updated_area[1]);
+          else
+            invalidate_all = TRUE;
+        }
+    }
+
+  if (invalidate_all)
+    {
+      window_rect.x = 0;
+      window_rect.y = 0;
+      window_rect.width = gdk_window_get_width (window);
+      window_rect.height = gdk_window_get_height (window);
+
+      /* If nothing else is known, repaint everything so that the back
+         buffer is fully up-to-date for the swapbuffer */
+      cairo_region_union_rectangle (update_area, &window_rect);
+    }
+}
+
+static void
+gdk_x11_gl_context_end_frame (GdkGLContext   *context,
+                              cairo_region_t *painted,
+                              cairo_region_t *damage)
+{
+  GdkX11GLContext *context_x11 = GDK_X11_GL_CONTEXT (context);
+  GdkWindow *window = gdk_gl_context_get_window (context);
+  GdkDisplay *display = gdk_window_get_display (window);
+  EGLDisplay edpy = gdk_x11_display_get_egl_display (display);
+  EGLSurface esurface;
+
+  gdk_gl_context_make_current (context);
+
+  esurface = gdk_x11_window_get_egl_surface (window, context_x11->egl_config);
+
+  if (GDK_X11_DISPLAY (display)->has_swap_buffers_with_damage)
+    {
+      int i, j, n_rects = cairo_region_num_rectangles (damage);
+      int window_height = gdk_window_get_height (window);
+      gboolean free_rects = FALSE;
+      cairo_rectangle_int_t rect;
+      EGLint *rects;
+      
+      if (n_rects < 16)
+        rects = g_newa (EGLint, n_rects * 4);
+      else
+        {
+          rects = g_new (EGLint, n_rects * 4);
+          free_rects = TRUE;
+        }
+
+      for (i = 0, j = 0; i < n_rects; i++)
+        {
+          cairo_region_get_rectangle (damage, i, &rect);
+          rects[j++] = rect.x;
+          rects[j++] = window_height - rect.height - rect.y;
+          rects[j++] = rect.width;
+          rects[j++] = rect.height;
+        }
+
+      eglSwapBuffersWithDamageEXT (edpy, esurface, rects, n_rects);
+
+      if (free_rects)
+        g_free (rects);
+    }
+  else
+    eglSwapBuffers (edpy, esurface);
+}
+
+#define N_EGL_ATTRS 16
+
+static gboolean
+gdk_x11_gl_context_realize (GdkGLContext  *context,
+                            GError       **error)
+{
+  GdkX11Display *display_x11;
+  GdkDisplay *display;
+  GdkX11GLContext *context_x11;
+  GdkGLContext *share;
+  GdkWindow *window;
+  gboolean debug_bit, compat_bit, legacy_bit, es_bit;
+  int major, minor;
+  EGLint context_attrs[N_EGL_ATTRS];
+
+  window = gdk_gl_context_get_window (context);
+  display = gdk_window_get_display (window);
+
+  if (!gdk_x11_display_init_gl (display))
+    {
+      g_set_error_literal (error, GDK_GL_ERROR, GDK_GL_ERROR_NOT_AVAILABLE,
+                           _("No GL implementation available"));
+      return FALSE;
+    }
+
+  context_x11 = GDK_X11_GL_CONTEXT (context);
+  display_x11 = GDK_X11_DISPLAY (display);
+  share = gdk_gl_context_get_shared_context (context);
+
+  gdk_gl_context_get_required_version (context, &major, &minor);
+  debug_bit = gdk_gl_context_get_debug_enabled (context);
+  compat_bit = gdk_gl_context_get_forward_compatible (context);
+
+  legacy_bit = !display_x11->has_create_context ||
+               (_gdk_gl_flags & GDK_GL_LEGACY) != 0;
+
+  es_bit = ((_gdk_gl_flags & GDK_GL_GLES) != 0 ||
+            (share != NULL && gdk_gl_context_get_use_es (share)));
+
+  if (es_bit)
+    {
+      context_attrs[0] = EGL_CONTEXT_CLIENT_VERSION;
+      context_attrs[1] = major == 3 ? 3 : 2;
+      context_attrs[2] = EGL_NONE;
+
+      eglBindAPI (EGL_OPENGL_ES_API);
+    }
+  else
+    {
+      int flags = 0;
+
+      if (!display_x11->has_create_context)
+        {
+          context_attrs[0] = EGL_NONE;
+        }
+      else
+        {
+          if (debug_bit)
+            flags |= EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR;
+          if (compat_bit)
+            flags |= EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE_BIT_KHR;
+
+          context_attrs[0] = EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR;
+          context_attrs[1] = legacy_bit
+                           ? EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR
+                           : EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR;
+          context_attrs[2] = EGL_CONTEXT_MAJOR_VERSION_KHR;
+          context_attrs[3] = legacy_bit ? 3 : major;
+          context_attrs[4] = EGL_CONTEXT_MINOR_VERSION_KHR;
+          context_attrs[5] = legacy_bit ? 0 : minor;
+          context_attrs[6] = EGL_CONTEXT_FLAGS_KHR;
+          context_attrs[7] = flags;
+          context_attrs[8] = EGL_NONE;
+        }
+
+      eglBindAPI (EGL_OPENGL_API);
+    }
+
+  GDK_NOTE (OPENGL,
+            g_message ("Creating EGL context (version:%d.%d, debug:%s, forward:%s, legacy:%s, es:%s)",
+                       major, minor,
+                       debug_bit ? "yes" : "no",
+                       compat_bit ? "yes" : "no",
+                       legacy_bit ? "yes" : "no",
+                       es_bit ? "yes" : "no"));
+
+  context_x11->egl_context =
+    eglCreateContext (gdk_x11_display_get_egl_display (display),
+                      context_x11->egl_config,
+                      share != NULL ? GDK_X11_GL_CONTEXT (share)->egl_context
+                                    : EGL_NO_CONTEXT,
+                      context_attrs);
+
+  /* If we're not asking for a GLES context, and we don't have the legacy bit set
+   * already, try again with a legacy context
+   */
+  if (context_x11->egl_context == NULL && !es_bit && !legacy_bit)
+    {
+      context_attrs[1] = EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR;
+      context_attrs[3] = 3;
+      context_attrs[5] = 0;
+
+      legacy_bit = TRUE;
+      es_bit = FALSE;
+
+      GDK_NOTE (OPENGL,
+                g_message ("Context creation failed; trying legacy EGL context"));
+
+      context_x11->egl_context =
+        eglCreateContext (gdk_x11_display_get_egl_display (display),
+                          context_x11->egl_config,
+                          share != NULL ? GDK_X11_GL_CONTEXT (share)->egl_context
+                                        : EGL_NO_CONTEXT,
+                          context_attrs);
+    }
+
+  if (context_x11->egl_context == NULL)
+    {
+      g_set_error_literal (error, GDK_GL_ERROR, GDK_GL_ERROR_NOT_AVAILABLE,
+                           _("Unable to create a GL context"));
+      return FALSE;
+    }
+
+  gdk_gl_context_set_is_legacy (context, legacy_bit);
+  gdk_gl_context_set_use_es (context, es_bit);
+
+  GDK_NOTE (OPENGL,
+            g_message ("Realized EGL context[%p]",
+                       context_x11->egl_context));
+
+  return TRUE;
+}
+
+static void
+gdk_x11_gl_context_dispose (GObject *gobject)
+{
+  GdkX11GLContext *context_x11 = GDK_X11_GL_CONTEXT (gobject);
+
+  if (context_x11->egl_context != NULL)
+    {
+      GdkGLContext *context = GDK_GL_CONTEXT (gobject);
+      GdkDisplay *display = gdk_gl_context_get_display (context);
+
+      if (eglGetCurrentContext () != context_x11->egl_context)
+        eglMakeCurrent (gdk_x11_display_get_egl_display (display),
+                        EGL_NO_SURFACE,
+                        EGL_NO_SURFACE,
+                        EGL_NO_CONTEXT);
+
+      GDK_NOTE (OPENGL, g_message ("Destroying EGL context"));
+      eglDestroyContext (gdk_x11_display_get_egl_display (display),
+                         context_x11->egl_context);
+      context_x11->egl_context = NULL;
+    }
+
+  G_OBJECT_CLASS (gdk_x11_gl_context_parent_class)->dispose (gobject);
+}
+
+static void
+gdk_x11_gl_context_class_init (GdkX11GLContextClass *klass)
+{
+  GdkGLContextClass *context_class = GDK_GL_CONTEXT_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  context_class->realize = gdk_x11_gl_context_realize;
+  context_class->end_frame = gdk_x11_gl_context_end_frame;
+
+  gobject_class->dispose = gdk_x11_gl_context_dispose;
+}
+
+static void
+gdk_x11_gl_context_init (GdkX11GLContext *self)
+{
+  self->do_frame_sync = TRUE;
+}
+
+static gboolean
+gdk_x11_display_init_gl (GdkDisplay *display)
+{
+  GdkX11Display *display_x11 = GDK_X11_DISPLAY (display);
+  EGLDisplay edpy;
+  int major, minor;
+
+  if (display_x11->supports_gl)
+    return TRUE;
+
+  if (_gdk_gl_flags & GDK_GL_DISABLE)
+    return FALSE;
+
+  edpy = gdk_x11_display_get_egl_display (display);
+  if (edpy == NULL)
+    return FALSE;
+
+  if (!eglInitialize (edpy, &major, &minor))
+    return FALSE;
+
+  if (!eglBindAPI (EGL_OPENGL_API))
+    return FALSE;
+
+  display_x11->supports_gl = TRUE;
+
+  display_x11->glx_version = major * 10 + minor;
+  display_x11->glx_error_base = 0; 
+  display_x11->glx_event_base = 0;
+
+  display_x11->has_create_context =
+    epoxy_has_egl_extension (edpy, "EGL_KHR_create_context");
+  display_x11->has_create_es2_context = FALSE;
+  display_x11->has_swap_interval = TRUE;
+  display_x11->has_texture_from_pixmap = FALSE;
+  display_x11->has_video_sync = FALSE;
+  display_x11->has_buffer_age =
+    epoxy_has_egl_extension (edpy, "EGL_EXT_buffer_age");
+  display_x11->has_sync_control = FALSE;
+  display_x11->has_multisample = FALSE;
+  display_x11->has_visual_rating = FALSE;
+  display_x11->has_swap_buffers_with_damage =
+    epoxy_has_egl_extension (edpy, "EGL_EXT_swap_buffers_with_damage");
+
+  GDK_NOTE (OPENGL,
+            g_message ("EGL X11 found\n"
+                       " - Vendor: %s\n"
+                       " - Version: %s\n"
+                       " - Client APIs: %s\n"
+                       " - Checked extensions:\n"
+                       "\t* EGL_KHR_create_context: %s\n"
+                       "\t* EGL_EXT_buffer_age: %s\n"
+                       "\t* EGL_EXT_swap_buffers_with_damage: %s",
+                       eglQueryString (edpy, EGL_VENDOR),
+                       eglQueryString (edpy, EGL_VERSION),
+                       eglQueryString (edpy, EGL_CLIENT_APIS),
+                       display_x11->has_create_context ? "yes" : "no",
+                       display_x11->has_buffer_age ? "yes" : "no",
+                       display_x11->has_swap_buffers_with_damage ? "yes" : "no"));
+
+  return TRUE;
+}
+
+void
+_gdk_x11_screen_update_visuals_for_gl (GdkScreen *screen)
+{
+  /* No-op; there's just no way to do the same trick we use
+   * with GLX to select an appropriate visual and cache it.
+   * For EGL-X11 we always pick the first visual and stick
+   * with it.
+   */
+}
+
+#define MAX_EGL_ATTRS 30
+
+static gboolean
+find_egl_config_for_window (GdkWindow  *window,
+                            EGLConfig  *config_out,
+                            GError    **error)
+{
+  GdkDisplay *display = gdk_window_get_display (window);
+  GdkVisual *visual = gdk_window_get_visual (window);
+  EGLint attrs[MAX_EGL_ATTRS];
+  EGLint count;
+  EGLDisplay egl_display;
+  EGLConfig *configs;
+  gboolean use_rgba;
+  int i = 0;
+
+  attrs[i++] = EGL_SURFACE_TYPE;
+  attrs[i++] = EGL_WINDOW_BIT;
+
+  attrs[i++] = EGL_COLOR_BUFFER_TYPE;
+  attrs[i++] = EGL_RGB_BUFFER;
+
+  attrs[i++] = EGL_RED_SIZE;
+  attrs[i++] = 1;
+  attrs[i++] = EGL_GREEN_SIZE;
+  attrs[i++] = 1;
+  attrs[i++] = EGL_BLUE_SIZE;
+  attrs[i++] = 1;
+
+  use_rgba = (visual == gdk_screen_get_rgba_visual (gdk_window_get_screen (window)));
+
+  if (use_rgba)
+    {
+      attrs[i++] = EGL_ALPHA_SIZE;
+      attrs[i++] = 1;
+    }
+  else
+    {
+      attrs[i++] = EGL_ALPHA_SIZE;
+      attrs[i++] = EGL_DONT_CARE;
+    }
+
+  attrs[i++] = EGL_NONE;
+  g_assert (i < MAX_EGL_ATTRS);
+
+  egl_display = gdk_x11_display_get_egl_display (display);
+  if (!eglChooseConfig (egl_display, attrs, NULL, 0, &count) || count < 1)
+    {
+      g_set_error_literal (error, GDK_GL_ERROR,
+                           GDK_GL_ERROR_UNSUPPORTED_FORMAT,
+                           _("No available configurations for the given pixel format"));
+      return FALSE;
+    }
+
+  configs = g_new (EGLConfig, count);
+  if (!eglChooseConfig (egl_display, attrs, configs, count, &count) || count < 1)
+    {
+      g_set_error_literal (error, GDK_GL_ERROR,
+                           GDK_GL_ERROR_UNSUPPORTED_FORMAT,
+                           _("No available configurations for the given pixel format"));
+      g_free (configs);
+      return FALSE;
+    }
+
+  if (config_out != NULL)
+    *config_out = configs[0];
+
+  g_free (configs);
+
+  return TRUE;
+}
+
+GdkGLContext *
+gdk_x11_window_create_gl_context (GdkWindow    *window,
+                                  gboolean      attached,
+                                  GdkGLContext *share,
+                                  GError      **error)
+{
+  GdkDisplay *display;
+  GdkX11GLContext *context;
+  EGLConfig config;
+
+  display = gdk_window_get_display (window);
+
+  if (!gdk_x11_display_init_gl (display))
+    {
+      g_set_error_literal (error, GDK_GL_ERROR,
+                           GDK_GL_ERROR_NOT_AVAILABLE,
+                           _("No GL implementation is available"));
+      return NULL;
+    }
+
+  if (!find_egl_config_for_window (window, &config, error))
+    return NULL;
+
+  context = g_object_new (GDK_TYPE_X11_GL_CONTEXT,
+                          "display", display,
+                          "window", window,
+                          "shared-context", share,
+                          NULL);
+
+  context->egl_config = config;
+  context->is_attached = attached;
+
+  return GDK_GL_CONTEXT (context);
+}
+
+gboolean
+gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
+                                         GdkGLContext *context)
+{
+  GdkX11GLContext *context_x11;
+  GdkWindow *window;
+  gboolean do_frame_sync = FALSE;
+  EGLSurface surface;
+  EGLDisplay egl_display;
+
+  egl_display = gdk_x11_display_get_egl_display (display);
+
+  if (context == NULL)
+    {
+      eglMakeCurrent (egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+      return TRUE;
+    }
+
+  window = gdk_gl_context_get_window (context);
+  context_x11 = GDK_X11_GL_CONTEXT (context);
+  if (context_x11->egl_context == NULL)
+    {
+      g_critical ("No EGL context associated to the GdkGLContext; you must "
+                  "call gdk_gl_context_realize() first.");
+      return FALSE;
+    }
+
+  GDK_NOTE (OPENGL,
+            g_message ("Making EGL context current"));
+
+  if (context_x11->is_attached)
+    surface = gdk_x11_window_get_egl_surface (window, context_x11->egl_config);
+  else
+    surface = gdk_x11_display_get_egl_dummy_surface (display, context_x11->egl_config);
+
+  if (!eglMakeCurrent (egl_display, surface, surface, context_x11->egl_context))
+    {
+      GDK_NOTE (OPENGL,
+                g_message ("Making EGL context current failed"));
+      return FALSE;
+    }
+
+  if (context_x11->is_attached)
+    {
+      /* If the WM is compositing there is no particular need to delay
+       * the swap when drawing on the offscreen, rendering to the screen
+       * happens later anyway, and its up to the compositor to sync that
+       * to the vblank. */
+      GdkScreen *screen = gdk_window_get_screen (window);
+
+      do_frame_sync = ! gdk_screen_is_composited (screen);
+
+      if (do_frame_sync != context_x11->do_frame_sync)
+        {
+          context_x11->do_frame_sync = do_frame_sync;
+
+          if (do_frame_sync)
+            eglSwapInterval (egl_display, 1);
+          else
+            eglSwapInterval (egl_display, 0);
+        }
+    }
+
+  return TRUE;
+}
+
+/**
+ * gdk_x11_display_get_glx_version:
+ * @display: a #GdkDisplay
+ * @major: (out): return location for the GLX major version
+ * @minor: (out): return location for the GLX minor version
+ *
+ * Retrieves the version of the GLX implementation.
+ *
+ * Returns: %TRUE if GLX is available
+ *
+ * Since: 3.16
+ */
+gboolean
+gdk_x11_display_get_glx_version (GdkDisplay *display,
+                                 gint       *major,
+                                 gint       *minor)
+{
+  g_return_val_if_fail (GDK_IS_DISPLAY (display), FALSE);
+
+  if (!GDK_IS_X11_DISPLAY (display))
+    return FALSE;
+
+  if (!gdk_x11_display_init_gl (display))
+    return FALSE;
+
+  if (major != NULL)
+    *major = GDK_X11_DISPLAY (display)->glx_version / 10;
+  if (minor != NULL)
+    *minor = GDK_X11_DISPLAY (display)->glx_version % 10;
+
+  return TRUE;
+}

--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -661,7 +661,8 @@ gdk_x11_gl_context_dispose (GObject *gobject)
       GdkGLContext *context = GDK_GL_CONTEXT (gobject);
       GdkDisplay *display = gdk_gl_context_get_display (context);
 
-      if (eglGetCurrentContext () != context_x11->egl_context)
+      /* Unset the current context if we're disposing it */
+      if (eglGetCurrentContext () == context_x11->egl_context)
         eglMakeCurrent (gdk_x11_display_get_egl_display (display),
                         EGL_NO_SURFACE,
                         EGL_NO_SURFACE,

--- a/gdk/x11/gdkglcontext-x11-eglx.c
+++ b/gdk/x11/gdkglcontext-x11-eglx.c
@@ -33,6 +33,10 @@
 #include "gdkx11property.h"
 #include <X11/Xatom.h>
 
+#ifdef HAVE_XCOMPOSITE
+#include <X11/extensions/Xcomposite.h>
+#endif
+
 #include "gdkinternals.h"
 
 #include "gdkintl.h"
@@ -873,6 +877,34 @@ gdk_x11_window_create_gl_context (GdkWindow    *window,
   return GDK_GL_CONTEXT (context);
 }
 
+#ifdef HAVE_XCOMPOSITE
+static gboolean
+window_is_composited (GdkDisplay *display,
+                      GdkWindow  *window)
+{
+  Display *dpy = GDK_DISPLAY_XDISPLAY (display);
+  Pixmap pixmap;
+
+  gdk_x11_display_error_trap_push (display);
+
+  /* This is kind of an expensive check, because there's no XComposite
+   * API to check if a Window has been unredirected. We check if there's
+   * a named Pixmap for it, and if we fail it means that the screen is
+   * not composited or the window is unredirected or not visible
+   */
+  pixmap = XCompositeNameWindowPixmap (dpy, GDK_WINDOW_XID (window));
+
+  XSync (GDK_DISPLAY_XDISPLAY (display), False);
+
+  if (gdk_x11_display_error_trap_pop (display))
+    return FALSE;
+
+  XFreePixmap (GDK_DISPLAY_XDISPLAY (display), pixmap);
+
+  return TRUE;
+}
+#endif /* HAVE_XCOMPOSITE */
+
 gboolean
 gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
                                          GdkGLContext *context)
@@ -917,13 +949,20 @@ gdk_x11_display_make_gl_context_current (GdkDisplay   *display,
 
   if (context_x11->is_attached)
     {
-      /* If the WM is compositing there is no particular need to delay
-       * the swap when drawing on the offscreen, rendering to the screen
-       * happens later anyway, and its up to the compositor to sync that
-       * to the vblank. */
       GdkScreen *screen = gdk_window_get_screen (window);
+      gboolean is_composited = gdk_screen_is_composited (screen);
 
-      do_frame_sync = ! gdk_screen_is_composited (screen);
+#ifdef HAVE_XCOMPOSITE
+      /* If the WM is compositing and the window is redirected there is no
+       * particular need to delay the swap when drawing on the offscreen,
+       * rendering to the screen happens later anyway, and its up to the
+       * compositor to sync that to the vblank.
+       */
+      if (is_composited)
+        is_composited = window_is_composited (display, window->impl_window);
+#endif /* HAVE_XCOMPOSITE */
+
+      do_frame_sync = !is_composited;
 
       if (do_frame_sync != context_x11->do_frame_sync)
         {

--- a/gdk/x11/gdkglcontext-x11.h
+++ b/gdk/x11/gdkglcontext-x11.h
@@ -24,9 +24,6 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 
-#include <epoxy/gl.h>
-#include <epoxy/glx.h>
-
 #include "gdkglcontextprivate.h"
 #include "gdkdisplayprivate.h"
 #include "gdkvisual.h"
@@ -36,27 +33,6 @@
 
 G_BEGIN_DECLS
 
-struct _GdkX11GLContext
-{
-  GdkGLContext parent_instance;
-
-  GLXContext glx_context;
-  GLXFBConfig glx_config;
-  GLXDrawable drawable;
-
-  guint is_attached : 1;
-  guint is_direct : 1;
-  guint do_frame_sync : 1;
-
-  guint do_blit_swap : 1;
-};
-
-struct _GdkX11GLContextClass
-{
-  GdkGLContextClass parent_class;
-};
-
-gboolean        gdk_x11_screen_init_gl                          (GdkScreen         *screen);
 GdkGLContext *  gdk_x11_window_create_gl_context                (GdkWindow         *window,
 								 gboolean           attached,
                                                                  GdkGLContext      *share,

--- a/gdk/x11/gdkscreen-x11.c
+++ b/gdk/x11/gdkscreen-x11.c
@@ -1050,7 +1050,7 @@ init_randr_support (GdkScreen *screen)
   /* NB: This is also needed for XSettings, so don't remove. */
   XSelectInput (GDK_SCREEN_XDISPLAY (screen),
                 x11_screen->xroot_window,
-                StructureNotifyMask);
+                StructureNotifyMask | PropertyChangeMask);
 
 #ifdef HAVE_RANDR
   if (!GDK_X11_DISPLAY (gdk_screen_get_display (screen))->have_randr12)

--- a/gdk/x11/gdkscreen-x11.c
+++ b/gdk/x11/gdkscreen-x11.c
@@ -560,7 +560,7 @@ init_randr15 (GdkScreen *screen, gboolean *changed)
 
       gdk_monitor_set_position (GDK_MONITOR (monitor), newgeo.x, newgeo.y);
       gdk_monitor_set_size (GDK_MONITOR (monitor), newgeo.width, newgeo.height);
-      g_object_notify (G_OBJECT (monitor), "workarea");
+      gdk_monitor_update_workarea (GDK_MONITOR (monitor));
       gdk_monitor_set_physical_size (GDK_MONITOR (monitor),
                                      rr_monitors[i].mwidth,
                                      rr_monitors[i].mheight);
@@ -743,7 +743,7 @@ init_randr13 (GdkScreen *screen, gboolean *changed)
 
           gdk_monitor_set_position (GDK_MONITOR (monitor), newgeo.x, newgeo.y);
           gdk_monitor_set_size (GDK_MONITOR (monitor), newgeo.width, newgeo.height);
-          g_object_notify (G_OBJECT (monitor), "workarea");
+          gdk_monitor_update_workarea (GDK_MONITOR (monitor));
           gdk_monitor_set_physical_size (GDK_MONITOR (monitor),
                                          output_info->mm_width,
                                          output_info->mm_height);
@@ -883,7 +883,7 @@ init_no_multihead (GdkScreen *screen, gboolean *changed)
   gdk_monitor_set_position (GDK_MONITOR (monitor), newgeo.x, newgeo.y);
   gdk_monitor_set_size (GDK_MONITOR (monitor), newgeo.width, newgeo.height);
 
-  g_object_notify (G_OBJECT (monitor), "workarea");
+  gdk_monitor_update_workarea (GDK_MONITOR (monitor));
   gdk_monitor_set_physical_size (GDK_MONITOR (monitor),
                                  gdk_x11_screen_get_width_mm (screen),
                                  gdk_x11_screen_get_height_mm (screen));

--- a/gdk/x11/gdkscreen-x11.h
+++ b/gdk/x11/gdkscreen-x11.h
@@ -46,6 +46,8 @@ struct _GdkX11Screen
   gint width;
   gint height;
 
+  GdkRectangle workarea;
+
   gint window_scale;
   gboolean fixed_window_scale;
 

--- a/gdk/x11/gdkwindow-x11.h
+++ b/gdk/x11/gdkwindow-x11.h
@@ -147,6 +147,7 @@ struct _GdkToplevelX11
    * to the extended update counter */
   guint pending_counter_value_is_extended : 1;
   guint configure_counter_value_is_extended : 1;
+  guint unredirected : 1;       /* _GTK_WINDOW_UNREDIRECTED */
 
   gulong map_serial;	/* Serial of last transition from unmapped */
   

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -554,7 +554,6 @@ gtk_private_h_sources =		\
 	gtkrenderborderprivate.h \
 	gtkrendericonprivate.h	\
 	gtkrenderprivate.h	\
-	gtkresources.h		\
 	gtkroundedboxprivate.h	\
 	gtksearchengine.h	\
 	gtksearchenginesimple.h	\
@@ -1171,20 +1170,18 @@ gtk_extra_sources =				\
 #
 # setup GTK+ sources and their dependencies
 #
-MAINTAINERCLEANFILES = \
+DISTCLEANFILES = \
 	$(gtk_built_sources) 			\
 	$(gtk_dbus_built_sources)		\
 	$(print_portal_built_sources)		\
-	$(stamp_files)
-
-DISTCLEANFILES = gtktypefuncs.inc
+	$(stamp_files)				\
+	gtktypefuncs.inc
 
 if OS_WIN32
 DISTCLEANFILES += gtk-win32.rc
 endif
 
 EXTRA_DIST += $(gtk_all_private_h_sources) $(gtk_extra_sources)
-EXTRA_DIST += $(gtk_built_sources)
 
 
 pkgdatadir = $(datadir)/gtk-$(GTK_API_VERSION)
@@ -1457,7 +1454,8 @@ $(srcdir)/gtktestutils.c: gtktypefuncs.inc
 lib_LTLIBRARIES = libgtk-3.la
 
 gtkincludedir = $(includedir)/gtk-3.0/gtk
-gtkinclude_HEADERS = $(gtk_public_h_sources) $(gtk_semi_private_h_sources) $(gtk_built_public_sources) gtkversion.h
+gtkinclude_HEADERS = $(gtk_public_h_sources) $(gtk_semi_private_h_sources)
+nodist_gtkinclude_HEADERS = $(gtk_built_public_sources) gtkversion.h
 
 a11yincludedir = $(includedir)/gtk-3.0/gtk/a11y
 a11yinclude_HEADERS= $(a11y_h_sources)
@@ -1516,6 +1514,7 @@ gtk_3_HEADERS_DIR = $(gtkincludedir)
 
 gtk_3_HEADERS_INST = \
 	$(gtkinclude_HEADERS)	\
+	$(nodist_gtkinclude_HEADERS)	\
 	$(a11y_h_sources)	\
 	$(deprecated_h_sources)
 
@@ -1597,7 +1596,7 @@ distclean-local:
 	fi
 
 if HAVE_INTROSPECTION
-introspected_pub_headers = $(filter-out %private.h gtktextdisplay.h gtktextlayout.h gtkx.h, $(gtkinclude_HEADERS) $(a11yinclude_HEADERS) $(deprecatedinclude_HEADERS))
+introspected_pub_headers = $(filter-out %private.h gtktextdisplay.h gtktextlayout.h gtkx.h, $(gtkinclude_HEADERS) $(a11yinclude_HEADERS) $(deprecatedinclude_HEADERS) $(nodist_gtkinclude_HEADERS))
 
 introspection_files = \
     $(introspected_pub_headers) \

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -1362,6 +1362,7 @@ adwaita_theme_scss = \
 	theme/Adwaita/_colors.scss 		\
 	theme/Adwaita/_common.scss 		\
 	theme/Adwaita/_drawing.scss 		\
+	theme/Adwaita/_endless.scss 		\
 	theme/Adwaita/gtk-contained-dark.scss 	\
 	theme/Adwaita/gtk-contained.scss 	\
 	$()

--- a/gtk/gtkapplication.c
+++ b/gtk/gtkapplication.c
@@ -383,6 +383,18 @@ static void
 gtk_application_after_emit (GApplication *application,
                             GVariant     *platform_data)
 {
+  const char *startup_notification_id = NULL;
+
+  g_variant_lookup (platform_data, "desktop-startup-id", "&s", &startup_notification_id);
+  if (startup_notification_id)
+    {
+      GdkDisplay *display;
+
+      display = gdk_display_get_default ();
+      if (display)
+        gdk_display_notify_startup_complete (display, startup_notification_id);
+    }
+
   gdk_threads_leave ();
 }
 

--- a/gtk/gtkapplication.c
+++ b/gtk/gtkapplication.c
@@ -347,6 +347,8 @@ static void
 gtk_application_add_platform_data (GApplication    *application,
                                    GVariantBuilder *builder)
 {
+  GdkDisplay *display;
+
   /* This is slightly evil.
    *
    * We don't have an impl here because we're remote so we can't figure
@@ -354,11 +356,16 @@ gtk_application_add_platform_data (GApplication    *application,
    *
    * So we do all the things... which currently is just one thing.
    */
-  const gchar *desktop_startup_id =
-    GDK_PRIVATE_CALL (gdk_get_desktop_startup_id) ();
-  if (desktop_startup_id)
-    g_variant_builder_add (builder, "{sv}", "desktop-startup-id",
-                           g_variant_new_string (desktop_startup_id));
+  display = gdk_display_get_default ();
+  if (display)
+    {
+      const gchar *startup_id;
+
+      startup_id = gdk_display_get_startup_notification_id (display);
+      if (startup_id && g_utf8_validate (startup_id, -1, NULL))
+        g_variant_builder_add (builder, "{sv}", "desktop-startup-id",
+                               g_variant_new_string (startup_id));
+    }
 }
 
 static void

--- a/gtk/gtkglarea.c
+++ b/gtk/gtkglarea.c
@@ -461,7 +461,7 @@ gtk_gl_area_allocate_buffers (GtkGLArea *area)
       glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
       if (gdk_gl_context_get_use_es (priv->context))
-        glTexImage2D (GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+        glTexImage2D (GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
       else
         glTexImage2D (GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
     }

--- a/gtk/gtkicontheme.c
+++ b/gtk/gtkicontheme.c
@@ -1371,6 +1371,15 @@ load_themes (GtkIconTheme *icon_theme)
   if (priv->current_theme)
     insert_theme (icon_theme, priv->current_theme);
 
+  /* Make sure to always look in EndlessOS theme in case GTK+ can't find
+   * the actual theme currently selected via GSettings, which can happen
+   * for instance when in a ENOSPC situation (i.e. XSettings's property
+   * 'Net/IconThemeName' would not be set to the value set in the GSettings
+   * schema for org.gnome.desktop.interface.icon-theme from the xsettings
+   * plugin in gnome-settings-manager, due to broken connectino via dconf).
+   */
+  insert_theme (icon_theme, "EndlessOS");
+
   /* Always look in the Adwaita, gnome and hicolor icon themes.
    * Looking in hicolor is mandated by the spec, looking in Adwaita
    * and gnome is a pragmatic solution to prevent missing icons in

--- a/gtk/gtkmain.c
+++ b/gtk/gtkmain.c
@@ -2228,8 +2228,13 @@ gtk_grab_add (GtkWidget *widget)
 {
   GtkWindowGroup *group;
   GtkWidget *old_grab_widget;
+  GtkWidget *toplevel;
 
   g_return_if_fail (widget != NULL);
+
+  toplevel = gtk_widget_get_toplevel (widget);
+  if (toplevel && gdk_window_get_window_type (gtk_widget_get_window (toplevel)) == GDK_WINDOW_OFFSCREEN)
+    return;
 
   if (!gtk_widget_has_grab (widget) && gtk_widget_is_sensitive (widget))
     {

--- a/gtk/gtkmain.c
+++ b/gtk/gtkmain.c
@@ -2321,9 +2321,14 @@ gtk_device_grab_add (GtkWidget *widget,
 {
   GtkWindowGroup *group;
   GtkWidget *old_grab_widget;
+  GdkWindow *toplevel;
 
   g_return_if_fail (GTK_IS_WIDGET (widget));
   g_return_if_fail (GDK_IS_DEVICE (device));
+  
+  toplevel = gdk_window_get_toplevel (gtk_widget_get_window (widget));
+  if (toplevel && gdk_window_get_window_type (toplevel) == GDK_WINDOW_OFFSCREEN)
+    return;
 
   group = gtk_main_get_window_group (widget);
   old_grab_widget = gtk_window_group_get_current_device_grab (group, device);

--- a/gtk/gtkplacessidebar.c
+++ b/gtk/gtkplacessidebar.c
@@ -169,10 +169,6 @@ struct _GtkPlacesSidebar {
   GtkSidebarRow *context_row;
   GSList *shortcuts;
 
-  GDBusProxy *hostnamed_proxy;
-  GCancellable *hostnamed_cancellable;
-  gchar *hostname;
-
   GtkPlacesOpenFlags open_flags;
 
   GActionGroup *action_group;
@@ -1358,19 +1354,6 @@ update_places (GtkPlacesSidebar *sidebar)
       g_object_unref (volume);
     }
   g_list_free (volumes);
-
-  /* file system root */
-  if (!sidebar->show_other_locations)
-    {
-      mount_uri = "file:///"; /* No need to strdup */
-      start_icon = g_themed_icon_new_with_default_fallbacks (ICON_NAME_FILESYSTEM);
-      add_place (sidebar, PLACES_BUILT_IN,
-                 SECTION_MOUNTS,
-                 sidebar->hostname, start_icon, NULL, mount_uri,
-                 NULL, NULL, NULL, NULL, 0,
-                 _("Open the contents of the file system"));
-      g_object_unref (start_icon);
-    }
 
   /* add mounts that has no volume (/etc/mtab mounts, ftp, sftp,...) */
   mounts = g_volume_monitor_get_mounts (sidebar->volume_monitor);
@@ -3958,66 +3941,6 @@ list_box_sort_func (GtkListBoxRow *row1,
 }
 
 static void
-update_hostname (GtkPlacesSidebar *sidebar)
-{
-  GVariant *variant;
-  gsize len;
-  const gchar *hostname;
-
-  if (sidebar->hostnamed_proxy == NULL)
-    return;
-
-  variant = g_dbus_proxy_get_cached_property (sidebar->hostnamed_proxy,
-                                              "PrettyHostname");
-  if (variant == NULL)
-    return;
-
-  hostname = g_variant_get_string (variant, &len);
-  if (len > 0 &&
-      g_strcmp0 (sidebar->hostname, hostname) != 0)
-    {
-      g_free (sidebar->hostname);
-      sidebar->hostname = g_strdup (hostname);
-      update_places (sidebar);
-    }
-
-  g_variant_unref (variant);
-}
-
-static void
-hostname_proxy_new_cb (GObject      *source_object,
-                       GAsyncResult *res,
-                       gpointer      user_data)
-{
-  GtkPlacesSidebar *sidebar = user_data;
-  GError *error = NULL;
-  GDBusProxy *proxy;
-
-  proxy = g_dbus_proxy_new_for_bus_finish (res, &error);
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-    {
-      g_error_free (error);
-      return;
-    }
-
-  sidebar->hostnamed_proxy = proxy;
-  g_clear_object (&sidebar->hostnamed_cancellable);
-
-  if (error != NULL)
-    {
-      g_debug ("Failed to create D-Bus proxy: %s", error->message);
-      g_error_free (error);
-      return;
-    }
-
-  g_signal_connect_swapped (sidebar->hostnamed_proxy,
-                            "g-properties-changed",
-                            G_CALLBACK (update_hostname),
-                            sidebar);
-  update_hostname (sidebar);
-}
-
-static void
 create_volume_monitor (GtkPlacesSidebar *sidebar)
 {
   g_assert (sidebar->volume_monitor == NULL);
@@ -4154,18 +4077,6 @@ gtk_places_sidebar_init (GtkPlacesSidebar *sidebar)
   sidebar->drag_data_info = DND_UNKNOWN;
 
   gtk_container_add (GTK_CONTAINER (sidebar), sidebar->list_box);
-
-  sidebar->hostname = g_strdup (_("Computer"));
-  sidebar->hostnamed_cancellable = g_cancellable_new ();
-  g_dbus_proxy_new_for_bus (G_BUS_TYPE_SYSTEM,
-                            G_DBUS_PROXY_FLAGS_GET_INVALIDATED_PROPERTIES,
-                            NULL,
-                            "org.freedesktop.hostname1",
-                            "/org/freedesktop/hostname1",
-                            "org.freedesktop.hostname1",
-                            sidebar->hostnamed_cancellable,
-                            hostname_proxy_new_cb,
-                            sidebar);
 
   sidebar->drop_state = DROP_STATE_NORMAL;
 
@@ -4379,16 +4290,6 @@ gtk_places_sidebar_dispose (GObject *object)
                                             update_places, sidebar);
       g_clear_object (&sidebar->volume_monitor);
     }
-
-  if (sidebar->hostnamed_cancellable != NULL)
-    {
-      g_cancellable_cancel (sidebar->hostnamed_cancellable);
-      g_clear_object (&sidebar->hostnamed_cancellable);
-    }
-
-  g_clear_object (&sidebar->hostnamed_proxy);
-  g_free (sidebar->hostname);
-  sidebar->hostname = NULL;
 
   if (sidebar->gtk_settings)
     {

--- a/gtk/theme/Adwaita/_endless.scss
+++ b/gtk/theme/Adwaita/_endless.scss
@@ -1,0 +1,101 @@
+headerbar.default-decoration {
+  color: #dfdbd2;
+  background-image: linear-gradient(to bottom,
+                                    #464646,
+                                    #1e1e1e);
+  box-shadow: inset 0 -1px #0a0a0a,
+              inset 0 -2px #292929,
+              inset 0 1px  #4d4d4d;
+  border: none;
+  min-height: 36px;
+
+  &:dir(rtl) {
+    padding: 0 16px 0 6px;
+  }
+
+  &:dir(ltr) {
+    padding: 0 6px 0 16px;
+  }
+
+  &.maximized {
+    box-shadow: inset 0 -1px #0a0a0a,
+                inset 0 -2px #292929;
+  }
+
+  &:backdrop {
+    color: #807d78;
+    background-image: linear-gradient(to bottom,
+                                      #282828,
+                                      #1e1e1e);
+    box-shadow: inset 0 -1px #0a0a0a,
+                inset 0 -2px #292929,
+                inset 0 1px  #303030;
+
+    &.maximized {
+      box-shadow: inset 0 -1px #0a0a0a,
+                  inset 0 -2px #292929;
+    }
+  }
+
+  button.titlebutton {
+      color: #8c8c8c;
+      background-image: none;
+      border: none;
+      border-image: none;
+      box-shadow: none;
+      background-color: transparent;
+      border-radius: 2px;
+      -gtk-icon-shadow: none;
+
+      &:hover {
+        color: #dcdcdc;
+        background-image: linear-gradient(to bottom,
+                                          rgb(131, 131, 131) 2%,
+                                          rgb(108, 108, 108) 5%,
+                                          rgb(68, 68, 68))
+      }
+      &:active {
+        color: #787878;
+        background-image: linear-gradient(to bottom,
+                                          rgb(79, 79, 79) 2%,
+                                          rgb(71, 71, 71) 5%,
+                                          rgb(67, 67, 67))
+      }
+      &:backdrop {
+        background-image: none;
+      }
+  }
+}
+
+/* Set dark background for Chrome and Chromium > 59 top bar */
+.header-bar.chromium {
+  color: #807d78;
+  background-image: linear-gradient(to bottom,
+                                    #464646,
+                                    #1e1e1e);
+  box-shadow: none;
+}
+
+.header-bar.chromium:backdrop {
+  color: #807d78;
+  background-image: linear-gradient(to bottom,
+                                    #282828,
+                                    #1e1e1e);
+}
+
+/* Fix color of window management buttons for Chrome top bar */
+button.titlebutton.chromium {
+  color: #8c8c8c;
+  -gtk-icon-shadow: none;
+}
+
+button.titlebutton.chromium:hover {
+  color: #dcdcdc;
+  background-image: none;
+  border: none;
+  box-shadow: none;
+}
+
+button.titlebutton.chromium:active {
+  color: #787878;
+}

--- a/gtk/theme/Adwaita/gtk-contained-dark.css
+++ b/gtk/theme/Adwaita/gtk-contained-dark.css
@@ -2072,3 +2072,34 @@ read if you used those and something break with a version upgrade you're on your
 @define-color wm_button_active_color_b shade(#353535, 0.89);
 @define-color wm_button_active_color_c shade(#353535, 0.9);
 @define-color content_view_bg #2d2d2d;
+headerbar.default-decoration { color: #dfdbd2; background-image: linear-gradient(to bottom, #464646, #1e1e1e); box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #4d4d4d; border: none; min-height: 36px; }
+
+headerbar.default-decoration:dir(rtl) { padding: 0 16px 0 6px; }
+
+headerbar.default-decoration:dir(ltr) { padding: 0 6px 0 16px; }
+
+headerbar.default-decoration.maximized { box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+
+headerbar.default-decoration:backdrop { color: #807d78; background-image: linear-gradient(to bottom, #282828, #1e1e1e); box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #303030; }
+
+headerbar.default-decoration:backdrop.maximized { box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+
+headerbar.default-decoration button.titlebutton { color: #8c8c8c; background-image: none; border: none; border-image: none; box-shadow: none; background-color: transparent; border-radius: 2px; -gtk-icon-shadow: none; }
+
+headerbar.default-decoration button.titlebutton:hover { color: #dcdcdc; background-image: linear-gradient(to bottom, #838383 2%, #6c6c6c 5%, #444444); }
+
+headerbar.default-decoration button.titlebutton:active { color: #787878; background-image: linear-gradient(to bottom, #4f4f4f 2%, #474747 5%, #434343); }
+
+headerbar.default-decoration button.titlebutton:backdrop { background-image: none; }
+
+/* Set dark background for Chrome and Chromium > 59 top bar */
+.header-bar.chromium { color: #807d78; background-image: linear-gradient(to bottom, #464646, #1e1e1e); box-shadow: none; }
+
+.header-bar.chromium:backdrop { color: #807d78; background-image: linear-gradient(to bottom, #282828, #1e1e1e); }
+
+/* Fix color of window management buttons for Chrome top bar */
+button.titlebutton.chromium { color: #8c8c8c; -gtk-icon-shadow: none; }
+
+button.titlebutton.chromium:hover { color: #dcdcdc; background-image: none; border: none; box-shadow: none; }
+
+button.titlebutton.chromium:active { color: #787878; }

--- a/gtk/theme/Adwaita/gtk-contained-dark.scss
+++ b/gtk/theme/Adwaita/gtk-contained-dark.scss
@@ -4,3 +4,4 @@ $variant: 'dark';
 @import 'drawing';
 @import 'common';
 @import 'colors-public';
+@import 'endless';

--- a/gtk/theme/Adwaita/gtk-contained.css
+++ b/gtk/theme/Adwaita/gtk-contained.css
@@ -2088,3 +2088,34 @@ read if you used those and something break with a version upgrade you're on your
 @define-color wm_button_active_color_b shade(#f6f5f4, 0.89);
 @define-color wm_button_active_color_c shade(#f6f5f4, 0.9);
 @define-color content_view_bg #ffffff;
+headerbar.default-decoration { color: #dfdbd2; background-image: linear-gradient(to bottom, #464646, #1e1e1e); box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #4d4d4d; border: none; min-height: 36px; }
+
+headerbar.default-decoration:dir(rtl) { padding: 0 16px 0 6px; }
+
+headerbar.default-decoration:dir(ltr) { padding: 0 6px 0 16px; }
+
+headerbar.default-decoration.maximized { box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+
+headerbar.default-decoration:backdrop { color: #807d78; background-image: linear-gradient(to bottom, #282828, #1e1e1e); box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929, inset 0 1px  #303030; }
+
+headerbar.default-decoration:backdrop.maximized { box-shadow: inset 0 -1px #0a0a0a, inset 0 -2px #292929; }
+
+headerbar.default-decoration button.titlebutton { color: #8c8c8c; background-image: none; border: none; border-image: none; box-shadow: none; background-color: transparent; border-radius: 2px; -gtk-icon-shadow: none; }
+
+headerbar.default-decoration button.titlebutton:hover { color: #dcdcdc; background-image: linear-gradient(to bottom, #838383 2%, #6c6c6c 5%, #444444); }
+
+headerbar.default-decoration button.titlebutton:active { color: #787878; background-image: linear-gradient(to bottom, #4f4f4f 2%, #474747 5%, #434343); }
+
+headerbar.default-decoration button.titlebutton:backdrop { background-image: none; }
+
+/* Set dark background for Chrome and Chromium > 59 top bar */
+.header-bar.chromium { color: #807d78; background-image: linear-gradient(to bottom, #464646, #1e1e1e); box-shadow: none; }
+
+.header-bar.chromium:backdrop { color: #807d78; background-image: linear-gradient(to bottom, #282828, #1e1e1e); }
+
+/* Fix color of window management buttons for Chrome top bar */
+button.titlebutton.chromium { color: #8c8c8c; -gtk-icon-shadow: none; }
+
+button.titlebutton.chromium:hover { color: #dcdcdc; background-image: none; border: none; box-shadow: none; }
+
+button.titlebutton.chromium:active { color: #787878; }

--- a/gtk/theme/Adwaita/gtk-contained.scss
+++ b/gtk/theme/Adwaita/gtk-contained.scss
@@ -10,3 +10,4 @@ $variant: 'light';
 @import 'drawing';
 @import 'common';
 @import 'colors-public';
+@import 'endless';

--- a/gtk/updateiconcache.c
+++ b/gtk/updateiconcache.c
@@ -676,7 +676,7 @@ scan_directory (const gchar *base_path,
 		      directories = g_list_append (directories, g_strdup (subdir));
 		    }
 		  else
-		    dir_index = 0xffff;
+		    continue;
 		}
 
 	      image = g_new0 (Image, 1);

--- a/modules/input/imviqr.c
+++ b/modules/input/imviqr.c
@@ -242,7 +242,7 @@ static const GtkIMContextInfo viqr_info = {
   NC_("input method menu", "Vietnamese (VIQR)"), /* Human readable name */
   GETTEXT_PACKAGE,	   /* Translation domain */
    GTK_LOCALEDIR,	   /* Dir for bindtextdomain (not strictly needed for "gtk+") */
-  "vi"			   /* Languages for which this module is the default */
+  ""			   /* Languages for which this module is the default */
 };
 
 static const GtkIMContextInfo *info_list[] = {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,8 @@
 ## Makefile.am for gtk+/tests
 include $(top_srcdir)/Makefile.decl
 
+CLEANFILES =
+
 SUBDIRS = visuals
 
 AM_CPPFLAGS =				\
@@ -308,6 +310,13 @@ testtitlebar_DEPENDENCIES = $(TEST_DEPS)
 testwindowsize_DEPENDENCIES = $(TEST_DEPS)
 listmodel_DEPENDENCIES = $(TEST_DEPS)
 
+# Add the blur files in BUILT_SOURCES instead of in blur_performance_SOURCES
+# directly because we want them to be generated before build time.
+BUILT_SOURCES = \
+	gtkcairoblurprivate.h 	\
+	gtkcairoblur.c
+
+
 animated_resizing_SOURCES = 	\
 	animated-resizing.c	\
 	frame-stats.c		\
@@ -331,7 +340,7 @@ scrolling_performance_SOURCES = \
 
 blur_performance_SOURCES = \
 	blur-performance.c	\
-	../gtk/gtkcairoblur.c
+	$(BUILT_SOURCES)
 
 video_timer_SOURCES = 	\
 	video-timer.c	\
@@ -575,5 +584,13 @@ EXTRA_DIST += 			\
 	popover.ui		\
 	selectionmode.ui	\
 	meson.build
+
+gtkcairoblurprivate.h: $(top_srcdir)/gtk/gtkcairoblurprivate.h
+	$(AM_V_GEN) $(LN_S) $^ $@
+
+gtkcairoblur.c: $(top_srcdir)/gtk/gtkcairoblur.c
+	$(AM_V_GEN) $(LN_S) $^ $@
+
+CLEANFILES += gtkcairoblurprivate.h gtkcairoblur.c
 
 -include $(top_srcdir)/git.mk

--- a/testsuite/a11y/Makefile.am
+++ b/testsuite/a11y/Makefile.am
@@ -28,8 +28,6 @@ TESTS_ENVIRONMENT = 			\
 	GTK_CSD=1			\
 	G_ENABLE_DIAGNOSTIC=0
 
-TEST_PROGS += accessibility-dump
-
 TEST_PROGS += tree-performance
 
 TEST_PROGS += text
@@ -89,7 +87,6 @@ testdata = \
 	$(NULL)
 
 test_in_files = \
-	a11ytests.test.in \
 	a11ychildren.test.in \
 	a11ytree.test.in \
 	a11yvalue.test.in \

--- a/testsuite/css/style/Makefile.am
+++ b/testsuite/css/style/Makefile.am
@@ -25,6 +25,8 @@ test_css_style_LDADD = \
 
 test_css_style_SOURCES = \
         test-css-style.c		\
+	$(NULL)
+nodist_test_css_style_SOURCES = \
 	resources.c			\
 	$(NULL)
 
@@ -39,7 +41,8 @@ test_data = \
 	nth-child.ui		nth-child.css	        nth-child.nodes         \
 	$(NULL)
 
-BUILT_SOURCES = resources.c
+BUILT_SOURCES = $(nodist_test_css_style_SOURCES)
+CLEANFILES += $(BUILT_SOURCES)
 
 resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(builddir)/test-css-style.gresource.xml)
 

--- a/testsuite/gtk/Makefile.am
+++ b/testsuite/gtk/Makefile.am
@@ -150,8 +150,10 @@ keyhash_CFLAGS =					\
 keyhash_SOURCES	=		\
 	keyhash.c 		\
 	gtkkeyhash.c 		\
-	gtkresources.c 		\
 	gtkprivate.c 		\
+	$(NULL)
+nodist_keyhash_SOURCES	=	\
+	gtkresources.c 		\
 	$(NULL)
 
 gtkkeyhash.c: $(top_srcdir)/gtk/gtkkeyhash.c

--- a/testsuite/gtk/defaultvalue.c
+++ b/testsuite/gtk/defaultvalue.c
@@ -489,6 +489,10 @@ main (int argc, char **argv)
       if (otypes[i] == GTK_TYPE_FILE_CHOOSER_NATIVE)
         continue;
 
+      /* https://gitlab.gnome.org/GNOME/gdk-pixbuf/issues/91 */
+      if (otypes[i] == GDK_TYPE_PIXBUF)
+        continue;
+
       testname = g_strdup_printf ("/Default Values/%s",
 				  g_type_name (otypes[i]));
       g_test_add_data_func (testname,

--- a/testsuite/reftests/gtk-reftest.c
+++ b/testsuite/reftests/gtk-reftest.c
@@ -257,6 +257,20 @@ save_image (cairo_surface_t *surface,
   g_free (filename);
 }
 
+static gboolean
+known_fail(const char *test_name)
+{
+  char *filename = get_test_file (test_name, ".ui.known_fail", TRUE);
+
+  if (filename)
+    {
+      g_free (filename);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
 static void
 test_ui_file (GFile *file)
 {
@@ -289,7 +303,13 @@ test_ui_file (GFile *file)
   if (diff_image)
     {
       save_image (diff_image, ui_file, ".diff.png");
-      g_test_fail ();
+      if (known_fail(ui_file))
+        {
+          printf("KNOWN FAIL: ");
+          g_test_message ("KNOWN FAIL: %s", ui_file);
+        }
+      else
+        g_test_fail ();
     }
 
   remove_extra_css (provider);


### PR DESCRIPTION
Pull request for comparison with upstream branch only; this should be force-pushed to master when it is ready.

# Notes #

- Upstream is the current gtk-3-24 branch (3.24.11 plus a few changes including a performance-related patch from Emmanuele and the removal of the defunct Mir backend)
- Merge base is 152e65f07 (Version_3.24.8-1-g152e65f07a)
- Could not build the debian packages locally except with nocheck. Tests would fail due to widgets having the wrong size, among other things. However, the tests pass fine on Jenkins so I am assuming that something from the environment is leaking in.

# Patches #

## Kept or dropped ##

- Added commit "gdk: Don't distribute generated files in tarballs", from Debian patches
- Added commit "gtk: Really don't distribute built files", from Debian patches
- Added commit "demos, examples, tests: Don't distribute built files", from Debian patches
- b463dd0661 Don't let offscreen widget do grabbing
- 0eaf4f0044 Do not allow devices in an offscreen hierarchy to take grabs.
- 3a1dce4716 Do not use VIQR input method for vi locale by default
- 0b1fa1e985 Don't list images from unknown directories in icon cache
- ca2df82bc7 Mark known failing tests as non-fatal
- 36a29eea51 Don't test default-constructed GdkPixbuf properties
- Added commit "Disable accessibility-dump (aka a11ytests) test", from Debian patches
- Added commit "build: Avoid redefining EXTRA_DIST" to fix build
  - proposed upstream as https://gitlab.gnome.org/GNOME/gtk/merge_requests/1101
- c4577e79e8 Remove Computer from file chooser
- d1ea6abace Comment out VS 2011/2012 project build
  - minor conflict, solved by commenting out the newly added vs16 line
- 469381131f gdk/x11: Add conditional support for EGL-X11
- 06c8f36ac7 gdk/x11: Force GLES when using EGL X11
- 641d8cb669 gl: Add private glReadPixels() wrapper
- fb63a9bc98 Use the generic names for glFramebuffer functions
- 21d42da929 glarea: Don't use GL_RGBA8 with OpengGL ES
- 4537aba2ff gdk_gl_context_download_texture() convert pixel data from rgba to argb.
- d8599930ac GdkX11GLContext: x11-eglx, implemented texture_from_surface()
- 195109a7a1 x11: Check if the window is composited for GL frame sync
- e3772e9717 Use non standard _GTK_WINDOW_UNREDIRECTED
- e20e9dbb49 x11: listen to property changes on the root window
- b97bd75edb x11: update screen size when workarea changes
- 9d394e071b x11: only notify a new workarea when it changed
  - trivial conflict due to two functions added in the same place, fixed
- cbbf3c0ccc tests: Fix build with external file
- ee85161dda display: Add new virtual gdk_display_get_startup_notification_id() method.
- f3c6189dfb application: Use the new API to get the startup notification ID
- fa3711a9a5 application: Complete startup notification sequence for remote invocations
- 0975dff9cd theme: add Endless-specific customizations
- 0d0b5d4bd3 theme: Set dark background for Chrome and Chromium > 59 top bar
  - squashed into theme commit, 0975dff9cd
- 026168a158 Remove shadows from titlebar buttons
  - squashed into theme commit, 0975dff9cd
- 3320e23b68 Remove style overrides for chromium user on the toolbar
  - squashed into theme commit, 0975dff9cd
- 264177a281 Use EndlessOS icon theme as first fallback after checking the current theme
- ee312b6a6c Unset the current EGL context if we're disposing it

## Dropped due to being already upstream ##

- 08206ad49d gtk/Makefile: Add generated gtktypefuncs.c to DISTCLEANFILES

## Dropped due to being obsolete ##

- 062c0754fb Consistently treat gdkenumtypes.[hc] as source files
  - Dropped, this was originally a Debian patch which is now dropped from Debian; fixed differently upstream
- d785ee280d Revert "Update some a11y test results"
  - Dropped, this was originally a Debian patch which is now dropped from Debian; no longer necessary and it now breaks the build

## Dropped due to being reverted later in the downstream series ##

- e48a68ebd9 display: Avoid unsetting the DESKTOP_STARTUP_ID variable too late
  - Reverted by 279b65b813 Revert "display: Avoid unsetting the DESKTOP_STARTUP_ID variable too late"


https://phabricator.endlessm.com/T27556