### PR TITLE
gtklistbox: Only unparent header rows if they haven’t been reused

### DIFF
--- a/gtk/gtklistbox.c
+++ b/gtk/gtklistbox.c
@@ -2426,8 +2426,11 @@ gtk_list_box_update_header (GtkListBox    *box,
                                 priv->update_header_func_target);
       if (old_header != ROW_PRIV (row)->header)
         {
-          if (old_header != NULL)
+          if (old_header != NULL &&
+              g_hash_table_lookup (priv->header_hash, old_header) == row)
             {
+              /* Only unparent the @old_header if it hasn’t been re-used as the
+               * header for a different row. */
               gtk_widget_unparent (old_header);
               g_hash_table_remove (priv->header_hash, old_header);
             }


### PR DESCRIPTION
It’s possible for code which uses a `GtkListBox` to reuse a single
header row, and move it around between rows. For example, this might
happen if the code has interactive widgets (like buttons) in the row,
and doesn’t want to continually recreate them and reattach signals to
them whenever the row headers change.

Unfortunately, this was broken, as the old header widget was
unconditionally unparented, even if it had just been set as the header
for a different row in the same `GtkListBox`. This left it assigned as
a child widget in the `GtkListBox` (so it was iterated over by
`forall`), but without its parent widget set.

Fix that by only unparenting the header if it hasn’t already been
assigned as the parent of a different row.

Signed-off-by: Philip Withnall <withnall@endlessm.com>
Forwarded: https://gitlab.gnome.org/GNOME/gtk/merge_requests/1114

---

Trivial backport of https://gitlab.gnome.org/GNOME/gtk/merge_requests/1114 from upstream, needed as the main fix for https://phabricator.endlessm.com/T27333.