### PR TITLE
fixup! Remove broken reftests

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -44,8 +44,13 @@ fi
 
 # These reftests fail on Jenkins
 touch testsuite/reftests/button-wrapping.ui.known_fail
+touch testsuite/reftests/cellrenderer-pixbuf-stock-rtl.ui.known_fail
+touch testsuite/reftests/flipping-icons.ui.known_fail
 touch testsuite/reftests/label-sizing.ui.known_fail
+touch testsuite/reftests/label-wrap-justify.ui.known_fail
 touch testsuite/reftests/quit-mnemonic.ui.known_fail
+touch testsuite/reftests/symbolic-icon-translucent-color.ui.known_fail
+touch testsuite/reftests/window-height-for-width.ui.known_fail
 
 cd "$olddir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/testsuite/reftests/Makefile.am
+++ b/testsuite/reftests/Makefile.am
@@ -65,8 +65,13 @@ gtk_reftest_SOURCES = \
 
 EXTRA_DIST += \
 	button-wrapping.ui.known_fail \
+	cellrenderer-pixbuf-stock-rtl.ui.known_fail \
+	flipping-icons.ui.known_fail \
 	label-sizing.ui.known_fail \
+	label-wrap-justify.ui.known_fail \
 	quit-mnemonic.ui.known_fail \
+	symbolic-icon-translucent-color.ui.known_fail \
+	window-height-for-width.ui.known_fail \
 	$(NULL)
 
 clean-local:


### PR DESCRIPTION
These tests are [currently marked as flaky when using meson](https://github.com/endlessm/gtk/blob/master/testsuite/reftests/meson.build#L430-L440) but remain enabled with autotools, lets sync them.

Note that [the autotools support to disable flaky tests](https://github.com/endlessm/gtk/commit/cdffe091c888bc3c9fc654459febe68823526525) is debian specific (imported from `debian/patches`) hence why I am not forwarding this change upstream (which seems to use meson by default).

https://phabricator.endlessm.com/T29566